### PR TITLE
feat(medicine): Add medicine end date flow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pkill -9 -f \"dart run repro_ab_tablehelper.dart\")",
+      "Bash(git status *)",
+      "Bash(python3 -)",
+      "Bash(git switch *)"
+    ]
+  }
+}

--- a/.claude/skills/flutter-pr/SKILL.md
+++ b/.claude/skills/flutter-pr/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: flutter-pr
+description: Generate a git branch name, commit message, and pull request description based on the current changes. Use when the user requests a PR, commit, submission, push, or is ready to finalize completed work.
+allowed-tools: Bash(git *), Bash(gh *)
+---
+
+# Git & Pull Request Output
+
+Generate the following after task completion and approval.
+
+## Base Branch (IMPORTANT)
+- Always use `main` as the base branch.
+- When creating the PR with GitHub CLI:
+
+```bash
+gh pr create --base main ...
+```
+## Branch Name
+
+Use conventional format:
+
+```
+fix/<short-description>
+feat/<short-description>
+refactor/<short-description>
+perf/<short-description>
+chore/<short-description>
+```
+
+Keep it lowercase, hyphen-separated, concise. Example: `feat/user-profile-cache`
+
+## Commit Message
+
+Follow conventional commit format:
+
+```
+<type>(<scope>): <short summary>
+
+<optional body — explain why, not what>
+```
+
+- Types: `fix`, `feat`, `refactor`, `perf`, `chore`, `test`, `docs`
+- Scope: feature or module name (e.g., `auth`, `cart`, `core`)
+- Summary: imperative mood, no period, max 72 characters
+- Body: only when the "why" isn't obvious from the summary
+
+Examples:
+```
+feat(auth): add biometric login support
+
+fix(cart): prevent duplicate items when rapidly tapping add button
+
+refactor(core): extract network client into standalone service
+```
+
+## Pull Request Title
+
+- Clear, descriptive, concise.
+- Match the commit type when possible.
+- Example: `feat(auth): Add biometric login support`
+
+## Pull Request Description
+
+Format in markdown. Keep it concise and to the point.
+
+```markdown
+## Summary
+Brief description of what this PR does and why.
+
+## Changes
+- Key change 1
+- Key change 2
+
+## Root Cause (bug fixes only)
+What caused the bug and how this PR addresses it.
+
+## Testing
+How the changes were verified.
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+**We Care** is a Flutter Personal Health Record (PHR) app for tracking medical history, chronic diseases, prescriptions, biometrics, and more. Arabic (RTL) is the primary/default locale, with English also supported.
+
+## Common commands
+
+```bash
+flutter pub get                       # install dependencies
+flutter analyze                       # lint (rules in analysis_options.yaml, based on flutter_lints)
+flutter test                          # run all tests
+flutter test test/widget_test.dart    # run a single test file
+
+# Code generation (required after editing any @RestApi service, Freezed model,
+# json_serializable model, or Hive adapter — these are hand-committed .g.dart/.freezed.dart files)
+dart run build_runner build --delete-conflicting-outputs
+dart run build_runner watch --delete-conflicting-outputs   # while iterating
+
+# Run the app — there is no single `flutter run`, always pick a flavor entrypoint:
+flutter run -t lib/main_development.dart
+flutter run -t lib/main_production.dart
+```
+
+There are two build flavors, `development` and `production`, selected by entrypoint file (`lib/main_development.dart`, `lib/main_production.dart`), not by `--flavor`. iOS flavor setup lives in `ios/setup_flavors.rb`.
+
+Localization strings are managed via `flutter_intl` (ARB files in `lib/l10n/intl_ar.arb`, `lib/l10n/intl_en.arb`, generated code in `lib/generated/`). Regenerate via the Flutter Intl IDE plugin or `flutter pub run intl_utils:generate` after editing ARB files.
+
+## Architecture
+
+**Feature-first structure.** Each of the 38 modules under `lib/features/` (allergy, medicine, x_ray, vaccine, surgeries, biometrics, essential_info, etc.) is self-contained and typically split into `*_data_entry` (create/edit) and `*_view` (read) sub-features, each with its own `logic/cubit`, `Presentation/views` (or `views`), and shared `data/` (models + repos). A feature's API endpoints live in a `<feature>_api_constants.dart` file, and its Retrofit service in `<feature>_services.dart` (generates `<feature>_services.g.dart`).
+
+**Layering per feature:** `View (Cubit/BlocBuilder)` → `Cubit` → `Repo` (wraps calls in `ApiResult.success`/`ApiResult.failure` via `ApiErrorHandler.handle`) → `*Services` (Retrofit/Dio interface) → REST API. Models are `json_serializable` (`.g.dart`) or occasionally `freezed`.
+
+**Dependency injection:** all services/repos/cubits are registered in `lib/core/di/dependency_injection.dart` via `get_it` (`getIt`), split into `setupAppServices()` (Retrofit services, singletons, share one `Dio` instance), `setupAppRepos()` (repos, lazy singletons), and `setupAppCubits()` (cubits, factories — new instance per screen). When adding a feature, register all three in this file following the existing per-feature grouping. Widely reused cross-feature logic (doctor specializations, countries, image/report uploads, module guidance videos) lives in `AppSharedRepo`/`SharedServices` (`lib/core/global/shared_repo.dart`, `shared_services.dart`) rather than being duplicated per feature.
+
+**Networking (`lib/core/networking/`):**
+- `dio_serices.dart` — single shared `Dio` instance (`DioServices.getDio()`). `addCareContextInterceptor()` attaches the `Authorization: Bearer <token>` header (read fresh from secure storage on every request) and, when in "care mode", an `Active-Medical-Profile` header carrying the active patient's ID. Also wires a debug-only logging interceptor, a cancellation interceptor (`DioServices.cancelRequests()`), and a naive retry-on-500 interceptor.
+- `auth_api_constants.dart` / `auth_service.dart` — auth endpoints (signup, login, OTP, forgot/reset password). No refresh-token mechanism exists; the bearer token is long-lived until manually cleared.
+- There is no logout endpoint or wired-up in-app "change password while authenticated" flow yet — only the forgot-password/reset-via-OTP flow is implemented. If asked to add these, coordinate the actual backend contract first rather than assuming REST conventions.
+
+**Local storage (`lib/core/Database/cach_helper.dart`):** `CacheHelper` wraps two stores — `SharedPreferences` for plain data and `FlutterSecureStorage` for sensitive data (auth token, cached FCM token). `clearAllData()` / `clearAllSecuredData()` exist for wiping state (e.g. on logout or fresh install) but must be called explicitly by feature code — nothing invokes them automatically except the first-run check in `main_development.dart`/`main_production.dart` (`checkIfLoggedInUser`).
+
+**Care/family access model:** `CareContextManager` (`lib/core/networking/models/care_context_manager_model.dart`) is a static, app-wide `ValueNotifier<CareContext?>` representing "care mode" — when a user is viewing/editing another patient's records via delegated access (see `allowed_care_access` feature), `CareContextManager.enter(...)` sets the active patient context, which the Dio interceptor and permission checks (`hasModuleAccessForViewMedicalFilesCategory`, `hasModuleAccessForDataEntryMedicalFilesCategory`) read to scope requests and gate UI. `MedicalModule` (`lib/core/models/medical_module_enum.dart`) is the canonical enum identifying each medical module for these permission checks — reuse it rather than string module names when adding permission-aware features.
+
+**Routing:** classic named routes — `Routes` (`lib/core/routing/routes.dart`) defines route name constants; `AppRouter` (`lib/core/routing/app_router.dart`) maps them to widgets via `onGenerateRoute`. Add both a `Routes` constant and an `AppRouter` case when adding a new screen.
+
+**Local persistence beyond auth:** some features (medicine alarms, medical complaints, genetic diseases) use `Hive` boxes registered/opened directly in `main_development.dart`/`main_production.dart` (not centrally abstracted) — if extending one of these, register any new `TypeAdapter` and open its box the same way, in both entrypoints.
+
+**Notifications:** `FcmTokenManager` (`lib/core/Services/fcm_token_manager.dart`) syncs the Firebase Messaging token to the backend, debounced, and caches the last-sent token in secure storage to avoid redundant syncs. It already exposes `clearCachedToken()` intended for logout, but nothing calls it yet.

--- a/lib/core/global/SharedWidgets/date_time_picker_widget.dart
+++ b/lib/core/global/SharedWidgets/date_time_picker_widget.dart
@@ -15,12 +15,16 @@ class DateTimePickerContainer extends StatefulWidget {
   final Color containerBorderColor;
   final bool? isForInsuranceExpiry;
 
+  /// Earliest selectable date. Defaults to 1900 when not set.
+  final DateTime? firstDate;
+
   const DateTimePickerContainer({
     super.key,
     required this.placeholderText,
     this.onDateSelected,
     this.containerBorderColor = AppColorsManager.textfieldOutsideBorderColor,
     this.isForInsuranceExpiry = false,
+    this.firstDate,
   });
 
   @override
@@ -32,10 +36,11 @@ class DatePickerContainerState extends State<DateTimePickerContainer> {
   final DateFormat dateFormat = DateFormat('yyyy-MM-dd', 'en');
 
   Future<void> _selectDate(BuildContext context) async {
+    final firstSelectableDate = widget.firstDate ?? DateTime(1900);
     DateTime? picked = await showDatePicker(
       context: context,
       initialDate: selectedDate ?? DateTime.now(),
-      firstDate: DateTime(1900),
+      firstDate: firstSelectableDate,
       lastDate: widget.isForInsuranceExpiry!
           ? DateTime.now().add(const Duration(days: 3650)) // 10 سنوات لقدام
           : DateTime.now(),

--- a/lib/features/allergy/allergy_api_constants.dart
+++ b/lib/features/allergy/allergy_api_constants.dart
@@ -19,7 +19,4 @@ class AllergyApiConstants {
   static const getAllergyDiseases = "/v1/All-allergies";
   static const getSingleAllergyDetailsById = "/v1/user-allergies";
   static const updateAllergyDocumentById = "/v1/allergy-data";
-  //filters
-  static const getSurgeriesFilters = "/ViewSectionSurgery/surgery-info";
-  static const getFilteredSurgeries = "/ViewSectionSurgery/filter";
 }

--- a/lib/features/allergy/allergy_services.dart
+++ b/lib/features/allergy/allergy_services.dart
@@ -89,15 +89,6 @@ abstract class AllergyServices {
     @Query("userType") String userType,
   );
 
-  @GET(AllergyApiConstants.getSurgeriesFilters)
-  Future<dynamic> getFilters(@Query("language") String language);
-
-  @GET(AllergyApiConstants.getFilteredSurgeries)
-  Future<GetUserSurgeriesResponseModal> getFilteredSurgeries(
-      @Query("language") String language,
-      @Query("surgeryName") String? surgeryName,
-      @Query("year") int? year);
-
   @DELETE(AllergyApiConstants.deleteAllergyById)
   Future<dynamic> deleteAllergyById(
     @Query("id") String id,

--- a/lib/features/allergy/allergy_view/logic/allergy_view_cubit.dart
+++ b/lib/features/allergy/allergy_view/logic/allergy_view_cubit.dart
@@ -78,22 +78,6 @@ class AllergyViewCubit extends Cubit<AllergyViewState> {
     await getAllergyDiseases(page: currentPage + 1);
   }
 
-  Future<void> getSurgeriesFilters() async {
-    emit(state.copyWith(requestStatus: RequestStatus.loading));
-    final result =
-        await allergyViewRepo.gettFilters(language: AppStrings.arabicLang);
-
-    result.when(success: (response) {
-      emit(state.copyWith(
-        requestStatus: RequestStatus.success,
-        yearsFilter: response.years,
-        surgeryNameFilter: response.surgeryNames,
-      ));
-    }, failure: (error) {
-      emit(state.copyWith(requestStatus: RequestStatus.failure));
-    });
-  }
-
   Future<void> getSingleAllergyDetailsById(String id) async {
     emit(state.copyWith(requestStatus: RequestStatus.loading));
     final result = await allergyViewRepo.getSingleAllergyDetailsById(

--- a/lib/features/allergy/allergy_view/logic/allergy_view_state.dart
+++ b/lib/features/allergy/allergy_view/logic/allergy_view_state.dart
@@ -6,7 +6,6 @@ class AllergyViewState extends Equatable {
   final List<AllergyDiseaseModel> userAllergies;
   final AllergyDetailsData? selectedAllergyDetails;
   final List<int> yearsFilter;
-  final List<String> surgeryNameFilter;
   final bool isDeleteRequest;
   final bool isLoadingMore;
   final ModuleGuidanceDataModel? moduleGuidanceData;
@@ -15,7 +14,6 @@ class AllergyViewState extends Equatable {
     this.responseMessage = '',
     this.requestStatus = RequestStatus.initial,
     this.yearsFilter = const [],
-    this.surgeryNameFilter = const ['الكل'],
     this.userAllergies = const [],
     this.selectedAllergyDetails,
     this.isDeleteRequest = false,
@@ -28,7 +26,6 @@ class AllergyViewState extends Equatable {
       responseMessage: '',
       requestStatus: RequestStatus.initial,
       yearsFilter: const [],
-      surgeryNameFilter: const ['الكل'],
       userAllergies: const [],
       selectedAllergyDetails: null,
       isDeleteRequest: false,
@@ -41,7 +38,6 @@ class AllergyViewState extends Equatable {
     String? responseMessage,
     RequestStatus? requestStatus,
     List<int>? yearsFilter,
-    List<String>? surgeryNameFilter,
     List<AllergyDiseaseModel>? userAllergies,
     AllergyDetailsData? selectedAllergyDetails,
     bool? isDeleteRequest,
@@ -52,7 +48,6 @@ class AllergyViewState extends Equatable {
       responseMessage: responseMessage ?? this.responseMessage,
       requestStatus: requestStatus ?? this.requestStatus,
       yearsFilter: yearsFilter ?? this.yearsFilter,
-      surgeryNameFilter: surgeryNameFilter ?? this.surgeryNameFilter,
       userAllergies: userAllergies ?? this.userAllergies,
       selectedAllergyDetails:
           selectedAllergyDetails ?? this.selectedAllergyDetails,
@@ -67,7 +62,6 @@ class AllergyViewState extends Equatable {
         responseMessage,
         requestStatus,
         yearsFilter,
-        surgeryNameFilter,
         userAllergies,
         selectedAllergyDetails,
         isDeleteRequest,

--- a/lib/features/allergy/data/repos/allergy_view_repo.dart
+++ b/lib/features/allergy/data/repos/allergy_view_repo.dart
@@ -5,23 +5,10 @@ import 'package:we_care/core/networking/api_result.dart';
 import 'package:we_care/features/allergy/allergy_services.dart';
 import 'package:we_care/features/allergy/data/models/allergy_details_data_model.dart';
 import 'package:we_care/features/allergy/data/models/allergy_disease_model.dart';
-import 'package:we_care/features/surgeries/data/models/get_surgeries_filters_response_model.dart';
-import 'package:we_care/features/surgeries/data/models/get_user_surgeries_response_model.dart';
 
 class AllergyViewRepo {
   final AllergyServices allergyServices;
   AllergyViewRepo({required this.allergyServices});
-
-  Future<ApiResult<GetSurgeriesFiltersResponseModel>> gettFilters(
-      {required String language}) async {
-    try {
-      final response = await allergyServices.getFilters(language);
-      return ApiResult.success(
-          GetSurgeriesFiltersResponseModel.fromJson(response['data']));
-    } catch (error) {
-      return ApiResult.failure(ApiErrorHandler.handle(error));
-    }
-  }
 
   Future<ApiResult<List<AllergyDiseaseModel>>> getAllergyDiseases(
       {required String language, int? page, int? pageSize}) async {
@@ -72,21 +59,6 @@ class AllergyViewRepo {
         UserTypes.patient.name.firstLetterToUpperCase,
       );
       return ApiResult.success(response['message']);
-    } catch (error) {
-      return ApiResult.failure(ApiErrorHandler.handle(error));
-    }
-  }
-
-  Future<ApiResult<GetUserSurgeriesResponseModal>> getFilteredSurgeries({
-    required String language,
-    int? year,
-    String? surgeryName,
-  }) async {
-    try {
-      final response = await allergyServices.getFilteredSurgeries(
-          language, surgeryName, year);
-
-      return ApiResult.success(response);
     } catch (error) {
       return ApiResult.failure(ApiErrorHandler.handle(error));
     }

--- a/lib/features/dental_module/dental_view/views/tooth_anatomy_view.dart
+++ b/lib/features/dental_module/dental_view/views/tooth_anatomy_view.dart
@@ -67,7 +67,7 @@ class ToothAnatomyView extends StatelessWidget {
                                 ? () {
                                     ModuleGuidanceAlertDialog.show(
                                       context,
-                                      title: "القياسات الحيوية",
+                                      title: "موديول الأسنان",
                                       description: state.moduleGuidanceData!
                                           .moduleGuidanceText!,
                                     );

--- a/lib/features/medicine/data/models/get_all_user_medicines_responce_model.dart
+++ b/lib/features/medicine/data/models/get_all_user_medicines_responce_model.dart
@@ -25,6 +25,10 @@ class GetAllUserMedicinesResponseModel {
 class MedicineModel {
   String id;
   String startDate;
+
+  /// Optional medicine end date ('yyyy-MM-dd'); null while the medicine has no
+  /// end date recorded.
+  String? endDate;
   String medicineName;
   String usageMethod;
   String dosageFrequency;
@@ -43,6 +47,7 @@ class MedicineModel {
   MedicineModel({
     required this.id,
     required this.startDate,
+    this.endDate,
     required this.medicineName,
     required this.usageMethod,
     required this.dosageFrequency,

--- a/lib/features/medicine/data/models/medicine_data_entry_request_body.dart
+++ b/lib/features/medicine/data/models/medicine_data_entry_request_body.dart
@@ -6,6 +6,11 @@ part 'medicine_data_entry_request_body.g.dart';
 @JsonSerializable()
 class MedicineDataEntryRequestBody {
   final String startDate;
+
+  /// Optional medicine end date ('yyyy-MM-dd'). Sent as null when the user does
+  /// not set one, since ending a medicine is normally done later from the
+  /// medicine details screen.
+  final String? endDate;
   final String medicineName;
   final String usageMethod;
   final String dosageFrequency;
@@ -22,6 +27,7 @@ class MedicineDataEntryRequestBody {
 
   MedicineDataEntryRequestBody({
     required this.startDate,
+    this.endDate,
     required this.medicineName,
     required this.usageMethod,
     required this.dosageFrequency,

--- a/lib/features/medicine/data/models/user_medical_history_details_model.dart
+++ b/lib/features/medicine/data/models/user_medical_history_details_model.dart
@@ -21,6 +21,9 @@ class UserMedicalHistoryDetailsModel extends Equatable {
   final List<NutritionTrackingModuleModel>? nutritionTrackingModule;
   final List<PhysicalActivityModuleModel>? physicalActivityModule;
   final SupplementsModuleModel? supplementsModule;
+  final List<VaccineModel>? vaccines;
+  final List<RiskyBehaviourModel>? riskyBehaviour;
+  final MonthlyHealthSurveyModel? monthlyHealthSurvey;
 
   const UserMedicalHistoryDetailsModel({
     this.basicInformation,
@@ -39,6 +42,9 @@ class UserMedicalHistoryDetailsModel extends Equatable {
     this.nutritionTrackingModule,
     this.physicalActivityModule,
     this.supplementsModule,
+    this.vaccines,
+    this.riskyBehaviour,
+    this.monthlyHealthSurvey,
   });
 
   factory UserMedicalHistoryDetailsModel.fromJson(Map<String, dynamic> json) =>
@@ -61,7 +67,12 @@ class UserMedicalHistoryDetailsModel extends Equatable {
       mentalIllnessModule == null &&
       (nutritionTrackingModule == null || nutritionTrackingModule!.isEmpty) &&
       (physicalActivityModule == null || physicalActivityModule!.isEmpty) &&
-      supplementsModule == null;
+      supplementsModule == null &&
+      (vaccines == null || vaccines!.isEmpty) &&
+      (riskyBehaviour == null || riskyBehaviour!.isEmpty) &&
+      (monthlyHealthSurvey == null ||
+          monthlyHealthSurvey!.rows == null ||
+          monthlyHealthSurvey!.rows!.isEmpty);
 
   @override
   List<Object?> get props => [
@@ -81,6 +92,9 @@ class UserMedicalHistoryDetailsModel extends Equatable {
         nutritionTrackingModule,
         physicalActivityModule,
         supplementsModule,
+        vaccines,
+        riskyBehaviour,
+        monthlyHealthSurvey,
       ];
 }
 
@@ -744,4 +758,98 @@ class SupplementModel extends Equatable {
         planType,
         noOfDaysDoseTaken,
       ];
+}
+
+@JsonSerializable()
+class VaccineModel extends Equatable {
+  final String? date;
+  final String? abbreviationCode;
+  final String? vaccineName;
+  final String? vaccineCategory;
+  final String? dose;
+  final String? targetDisease;
+  final String? vaccineActionDescription;
+
+  const VaccineModel({
+    this.date,
+    this.abbreviationCode,
+    this.vaccineName,
+    this.vaccineCategory,
+    this.dose,
+    this.targetDisease,
+    this.vaccineActionDescription,
+  });
+
+  factory VaccineModel.fromJson(Map<String, dynamic> json) =>
+      _$VaccineModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VaccineModelToJson(this);
+
+  @override
+  List<Object?> get props => [
+        date,
+        abbreviationCode,
+        vaccineName,
+        vaccineCategory,
+        dose,
+        targetDisease,
+        vaccineActionDescription,
+      ];
+}
+
+@JsonSerializable()
+class RiskyBehaviourModel extends Equatable {
+  final String? startDate;
+  final String? section;
+  final String? type;
+  final String? usageRate;
+  final String? status;
+
+  const RiskyBehaviourModel({
+    this.startDate,
+    this.section,
+    this.type,
+    this.usageRate,
+    this.status,
+  });
+
+  factory RiskyBehaviourModel.fromJson(Map<String, dynamic> json) =>
+      _$RiskyBehaviourModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RiskyBehaviourModelToJson(this);
+
+  @override
+  List<Object?> get props => [startDate, section, type, usageRate, status];
+}
+
+@JsonSerializable(explicitToJson: true)
+class MonthlyHealthSurveyModel extends Equatable {
+  final List<String>? columns;
+  final List<MonthlyHealthSurveyRowModel>? rows;
+
+  const MonthlyHealthSurveyModel({this.columns, this.rows});
+
+  factory MonthlyHealthSurveyModel.fromJson(Map<String, dynamic> json) =>
+      _$MonthlyHealthSurveyModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MonthlyHealthSurveyModelToJson(this);
+
+  @override
+  List<Object?> get props => [columns, rows];
+}
+
+@JsonSerializable()
+class MonthlyHealthSurveyRowModel extends Equatable {
+  final String? question;
+  final List<String?>? answersOverMonths;
+
+  const MonthlyHealthSurveyRowModel({this.question, this.answersOverMonths});
+
+  factory MonthlyHealthSurveyRowModel.fromJson(Map<String, dynamic> json) =>
+      _$MonthlyHealthSurveyRowModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MonthlyHealthSurveyRowModelToJson(this);
+
+  @override
+  List<Object?> get props => [question, answersOverMonths];
 }

--- a/lib/features/medicine/data/repos/medicine_view_repo.dart
+++ b/lib/features/medicine/data/repos/medicine_view_repo.dart
@@ -4,6 +4,10 @@ import 'package:we_care/features/medicine/data/models/get_all_user_medicines_res
 import 'package:we_care/features/medicine/data/models/get_medicines_filters_response_model.dart';
 import 'package:we_care/features/medicine/medicines_services.dart';
 
+/// The medicine continuity status plus, when the backend provides it, the date
+/// the medicine ended ('yyyy-MM-dd'). [endDate] is null when unknown.
+typedef MedicineStatusResult = ({bool isActiveMedicine, String? endDate});
+
 class MedicinesViewRepo {
   MedicinesViewRepo(
     MedicinesServices medicinesServices,
@@ -94,7 +98,7 @@ class MedicinesViewRepo {
     }
   }
 
-  Future<ApiResult<bool>> getMedicineActiveStatus({
+  Future<ApiResult<MedicineStatusResult>> getMedicineActiveStatus({
     required String medicineId,
     required String userType,
     required String language,
@@ -105,18 +109,21 @@ class MedicinesViewRepo {
         userType,
         language,
       );
-      return ApiResult.success(response["isActiveMedicine"]);
+      return ApiResult.success(_medicineStatusFrom(response));
     } catch (error) {
       return ApiResult.failure(ApiErrorHandler.handle(error));
     }
   }
 
-  Future<ApiResult<bool>> updateMedicineStatus({
+  /// Updates the medicine continuity status. When ending a medicine, [endDate]
+  /// is the user-picked end date ('yyyy-MM-dd'), sent under the `endDate` body
+  /// key and echoed back under the same key.
+  Future<ApiResult<MedicineStatusResult>> updateMedicineStatus({
     required String medicineId,
     required String userType,
     required String language,
     required bool isActiveMedicine,
-    required String date,
+    required String endDate,
   }) async {
     try {
       final response = await _medicinesServices.updateMedicineStatus(
@@ -124,13 +131,31 @@ class MedicinesViewRepo {
         userType,
         language,
         {
-          "startDate": date,
+          "endDate": endDate,
           "isActiveMedicine": isActiveMedicine,
         },
       );
-      return ApiResult.success(response["isActiveMedicine"]);
+      return ApiResult.success(_medicineStatusFrom(response));
     } catch (error) {
       return ApiResult.failure(ApiErrorHandler.handle(error));
     }
+  }
+
+  /// Reads `isActiveMedicine` and `endDate` from the response, tolerating both
+  /// shapes these two endpoints return (fields at the root, or wrapped in a
+  /// `data` envelope) and always taking the pair from the same payload. A
+  /// missing or empty `endDate` yields null instead of throwing.
+  MedicineStatusResult _medicineStatusFrom(dynamic response) {
+    final Map root = response is Map ? response : const {};
+    final data = root['data'];
+    final Map source = data is Map ? data : root;
+    final rawEndDate = source['endDate'] ?? root['endDate'];
+    return (
+      isActiveMedicine:
+          (source['isActiveMedicine'] ?? root['isActiveMedicine']) == true,
+      endDate: (rawEndDate is String && rawEndDate.isNotEmpty)
+          ? rawEndDate.split('T').first
+          : null,
+    );
   }
 }

--- a/lib/features/medicine/medicine_view/Presention/medicine_details_view.dart
+++ b/lib/features/medicine/medicine_view/Presention/medicine_details_view.dart
@@ -104,14 +104,17 @@ class MedicineDetailsView extends StatelessWidget {
                       isMedicineModule: true,
                       title: 'الدواء',
                       deleteFunction: () async {
+                        final medicineName =
+                            state.selectestMedicineDetails?.medicineName;
                         await BlocProvider.of<MedicineViewCubit>(context)
                             .deleteMedicineById(documentId);
                         if (!context.mounted) return;
+                        if (medicineName == null || medicineName.isEmpty) return;
                         unawaited(
                           context
                               .read<MedicineViewCubit>()
                               .cancelAlarmsCreatedBeforePerMedicine(
-                                state.selectestMedicineDetails!.medicineName,
+                                medicineName,
                               ),
                         );
                       },
@@ -243,113 +246,6 @@ class MedicineDetailsView extends StatelessWidget {
             },
           )),
     );
-  }
-}
-
-String calculateMedicineStatus(String startDateStr, String durationStr) {
-  try {
-    final dateParts = startDateStr.split('-');
-    if (dateParts.length != 3) throw FormatException("Invalid date format");
-
-    final year = int.parse(dateParts[0]);
-    final month = int.parse(dateParts[1]);
-    final day = int.parse(dateParts[2]);
-    final startDate = DateTime(year, month, day);
-    final now = DateTime.now();
-
-    Duration duration;
-
-    switch (durationStr) {
-      // --------------------
-      // 🔹 المدد الجديدة اليومية
-      // --------------------
-      case 'يوم واحد فقط':
-        duration = Duration(days: 1);
-        break;
-      case 'يومين':
-        duration = Duration(days: 2);
-        break;
-      case '3 أيام':
-        duration = Duration(days: 3);
-        break;
-      case '5 أيام':
-        duration = Duration(days: 5);
-        break;
-      case '7 أيام (أسبوع)':
-        duration = Duration(days: 7);
-        break;
-      case '10 أيام':
-        duration = Duration(days: 10);
-        break;
-      case '14 يومًا (أسبوعين)':
-        duration = Duration(days: 14);
-        break;
-      case '21 يومًا (3 أسابيع)':
-        duration = Duration(days: 21);
-        break;
-      case 'شهر (30 يومًا)':
-      case 'شهر':
-        duration = Duration(days: 30);
-        break;
-
-      // --------------------
-      // 🔹 مدد أسبوعية/شهرية متكررة (لا يمكن حساب نهاية ثابتة)
-      // --------------------
-      case 'يومين في الأسبوع':
-      case 'ثلاث أيام في الأسبوع':
-      case 'أسبوع كل شهر':
-      case 'عشر أيام كل شهر':
-      case 'استخدام موسمي':
-        return 'مستمر';
-
-      // --------------------
-      // 🔹 مدد غير محددة بزمن (تعتمد على الحالة)
-      // --------------------
-      case 'حتى انتهاء العبوة':
-      case 'حتى زوال الأعراض':
-      case 'حتى مراجعة الطبيب':
-      case 'حسب الحاجة':
-      case 'حسب استجابة المريض':
-      case 'حسب إرشادات الطبيب':
-      case 'مدى الحياة':
-        return 'غير محدد';
-
-      // --------------------
-      // 🔹 المدد القديمة (لا تُحذف)
-      // --------------------
-      case '6 أسابيع':
-        duration = Duration(days: 42);
-        break;
-      case 'شهرين':
-        duration = Duration(days: 60);
-        break;
-      case '3 أشهر':
-        duration = Duration(days: 90);
-        break;
-      case '6 أشهر':
-        duration = Duration(days: 180);
-        break;
-      case '9 أشهر':
-        duration = Duration(days: 270);
-        break;
-      case 'سنة واحدة':
-        duration = Duration(days: 365);
-        break;
-      case 'سنتين':
-        duration = Duration(days: 730);
-        break;
-      case '3 سنوات':
-        duration = Duration(days: 1095);
-        break;
-
-      default:
-        return 'غير محدد';
-    }
-
-    final endDate = startDate.add(duration);
-    return now.isBefore(endDate) ? 'مستمر' : 'متوقف';
-  } catch (e) {
-    return 'غير محدد';
   }
 }
 

--- a/lib/features/medicine/medicine_view/Presention/medicine_view.dart
+++ b/lib/features/medicine/medicine_view/Presention/medicine_view.dart
@@ -23,125 +23,133 @@ class MedicinesView extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocProvider<MedicineViewCubit>(
       create: (context) => getIt<MedicineViewCubit>()..init(),
-      child: RefreshIndicator(
-        onRefresh: () async {
-          BlocProvider.of<MedicineViewCubit>(context).init();
-        },
-        triggerMode: RefreshIndicatorTriggerMode.anywhere,
-        child: Scaffold(
-          appBar: AppBar(
-            toolbarHeight: 0,
-          ),
-          body: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Column(
-              children: [
-                BlocBuilder<MedicineViewCubit, MedicineViewState>(
-                  builder: (context, state) {
-                    final guidance = state.moduleGuidanceData;
-                    final hasVideo = guidance?.videoLink?.isNotEmpty == true;
-                    final hasText =
-                        guidance?.moduleGuidanceText?.isNotEmpty == true;
 
-                    return SharedAppBar(
-                      trailingActions: [
-                        CircleIconButton(
-                          icon: Icons.play_arrow,
-                          color: hasVideo
-                              ? AppColorsManager.mainDarkBlue
-                              : Colors.grey,
-                          onTap: hasVideo
-                              ? () => launchYouTubeVideo(guidance!.videoLink)
-                              : null,
-                        ),
-                        SizedBox(width: 12.w),
-                        CircleIconButton(
-                          icon: Icons.menu_book_outlined,
-                          color: hasText
-                              ? AppColorsManager.mainDarkBlue
-                              : Colors.grey,
-                          onTap: hasText
-                              ? () {
-                                  ModuleGuidanceAlertDialog.show(
-                                    context,
-                                    title: "الأدوية",
-                                    description: guidance!.moduleGuidanceText!,
-                                  );
-                                }
-                              : null,
-                        ),
-                      ],
-                    );
-                  },
-                ),
-                BlocBuilder<MedicineViewCubit, MedicineViewState>(
-                  buildWhen: (previous, current) =>
-                      previous.yearsFilter != current.yearsFilter ||
-                      previous.medicineNameFilter != current.medicineNameFilter,
-                  builder: (context, state) {
-                    return DataViewFiltersRow(
-                      filters: [
-                        FilterConfig(
-                            title: 'السنة',
-                            options: state.yearsFilter,
-                            isYearFilter: true),
-                        FilterConfig(
-                            title: 'اسم الدواء',
-                            options: state.medicineNameFilter,
-                            isMedicineFilter: true),
-                      ],
-                      onApply: (selectedFilters) {
-                        AppLogger.debug("Selected Filters: $selectedFilters");
-                        BlocProvider.of<MedicineViewCubit>(context)
-                            .getFilteredMedicinesList(
-                                year: selectedFilters['السنة'],
-                                medicineName:
-                                    selectedFilters['اسم الدواء'].toString());
-                      },
-                    );
-                  },
-                ),
-                verticalSpacing(24),
-                Text(
-                  "“اضغط على اسم الدواء لعرض تفاصيله”",
-                  style: AppTextStyles.customTextStyle,
-                  textAlign: TextAlign.center,
-                ),
-                verticalSpacing(16),
-                Text(
-                  "“اضغط على التاريخ لعرض جميع الادوية في ذلك التاريخ”",
-                  style: AppTextStyles.customTextStyle,
-                  textAlign: TextAlign.center,
-                ),
-                verticalSpacing(16),
-                // Scheduled Medicines Button
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: ElevatedButton.icon(
-                    onPressed: () async {
-                      await context
-                          .pushNamed(Routes.scheduledMedicinesListView);
+      /// Builder so the pull-to-refresh callback resolves the cubit from a
+      /// context *below* the provider — the outer build context has no
+      /// MedicineViewCubit above it.
+      child: Builder(
+        builder: (context) => RefreshIndicator(
+          onRefresh: () async {
+            await context.read<MedicineViewCubit>().init();
+          },
+          triggerMode: RefreshIndicatorTriggerMode.anywhere,
+          child: Scaffold(
+            appBar: AppBar(
+              toolbarHeight: 0,
+            ),
+            body: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Column(
+                children: [
+                  BlocBuilder<MedicineViewCubit, MedicineViewState>(
+                    builder: (context, state) {
+                      final guidance = state.moduleGuidanceData;
+                      final hasVideo = guidance?.videoLink?.isNotEmpty == true;
+                      final hasText =
+                          guidance?.moduleGuidanceText?.isNotEmpty == true;
+
+                      return SharedAppBar(
+                        trailingActions: [
+                          CircleIconButton(
+                            icon: Icons.play_arrow,
+                            color: hasVideo
+                                ? AppColorsManager.mainDarkBlue
+                                : Colors.grey,
+                            onTap: hasVideo
+                                ? () => launchYouTubeVideo(guidance!.videoLink)
+                                : null,
+                          ),
+                          SizedBox(width: 12.w),
+                          CircleIconButton(
+                            icon: Icons.menu_book_outlined,
+                            color: hasText
+                                ? AppColorsManager.mainDarkBlue
+                                : Colors.grey,
+                            onTap: hasText
+                                ? () {
+                                    ModuleGuidanceAlertDialog.show(
+                                      context,
+                                      title: "الأدوية",
+                                      description:
+                                          guidance!.moduleGuidanceText!,
+                                    );
+                                  }
+                                : null,
+                          ),
+                        ],
+                      );
                     },
-                    icon: const Icon(Icons.alarm, size: 20),
-                    label: const Text('الأدوية المجدولة'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColorsManager.mainDarkBlue,
-                      foregroundColor: Colors.white,
-                      minimumSize: const Size(double.infinity, 48),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
+                  ),
+                  BlocBuilder<MedicineViewCubit, MedicineViewState>(
+                    buildWhen: (previous, current) =>
+                        previous.yearsFilter != current.yearsFilter ||
+                        previous.medicineNameFilter !=
+                            current.medicineNameFilter,
+                    builder: (context, state) {
+                      return DataViewFiltersRow(
+                        filters: [
+                          FilterConfig(
+                              title: 'السنة',
+                              options: state.yearsFilter,
+                              isYearFilter: true),
+                          FilterConfig(
+                              title: 'اسم الدواء',
+                              options: state.medicineNameFilter,
+                              isMedicineFilter: true),
+                        ],
+                        onApply: (selectedFilters) {
+                          AppLogger.debug("Selected Filters: $selectedFilters");
+                          BlocProvider.of<MedicineViewCubit>(context)
+                              .getFilteredMedicinesList(
+                                  year: selectedFilters['السنة'],
+                                  medicineName:
+                                      selectedFilters['اسم الدواء'].toString());
+                        },
+                      );
+                    },
+                  ),
+                  verticalSpacing(24),
+                  Text(
+                    "“اضغط على اسم الدواء لعرض تفاصيله”",
+                    style: AppTextStyles.customTextStyle,
+                    textAlign: TextAlign.center,
+                  ),
+                  verticalSpacing(16),
+                  Text(
+                    "“اضغط على التاريخ لعرض جميع الادوية في ذلك التاريخ”",
+                    style: AppTextStyles.customTextStyle,
+                    textAlign: TextAlign.center,
+                  ),
+                  verticalSpacing(16),
+                  // Scheduled Medicines Button
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: ElevatedButton.icon(
+                      onPressed: () async {
+                        await context
+                            .pushNamed(Routes.scheduledMedicinesListView);
+                      },
+                      icon: const Icon(Icons.alarm, size: 20),
+                      label: const Text('الأدوية المجدولة'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColorsManager.mainDarkBlue,
+                        foregroundColor: Colors.white,
+                        minimumSize: const Size(double.infinity, 48),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
                       ),
                     ),
                   ),
-                ),
-                verticalSpacing(16),
-                Expanded(flex: 9, child: MedicineTable()),
-                verticalSpacing(16),
-                MedicineViewFooterRow(),
-                Spacer(
-                  flex: 1,
-                ),
-              ],
+                  verticalSpacing(16),
+                  Expanded(flex: 9, child: MedicineTable()),
+                  verticalSpacing(16),
+                  MedicineViewFooterRow(),
+                  Spacer(
+                    flex: 1,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/features/medicine/medicine_view/logic/medicine_view_cubit.dart
+++ b/lib/features/medicine/medicine_view/logic/medicine_view_cubit.dart
@@ -4,6 +4,8 @@ import 'package:alarm/alarm.dart';
 import 'package:bloc/bloc.dart';
 import 'package:hive/hive.dart';
 import 'package:we_care/core/global/Helpers/app_enums.dart';
+import 'package:we_care/core/global/Helpers/app_logger.dart';
+import 'package:we_care/core/global/Helpers/functions.dart';
 import 'package:we_care/core/global/app_strings.dart';
 import 'package:we_care/core/global/shared_repo.dart';
 import 'package:we_care/features/medicine/data/models/get_all_user_medicines_responce_model.dart';
@@ -12,7 +14,7 @@ import 'package:we_care/features/medicine/data/repos/medicine_view_repo.dart';
 import 'package:we_care/features/medicine/medicine_view/logic/medicine_view_state.dart';
 import 'package:we_care/features/medicine/medicines_api_constants.dart';
 
-class MedicineViewCubit extends Cubit<MedicineViewState> {
+class MedicineViewCubit extends Cubit<MedicineViewState> with SafeEmitMixin {
   MedicineViewCubit(this._medicinesViewRepo, this._appSharedRepo)
       : super(MedicineViewState.initial());
   final MedicinesViewRepo _medicinesViewRepo;
@@ -23,7 +25,7 @@ class MedicineViewCubit extends Cubit<MedicineViewState> {
   bool isLoadingMore = false;
 
   Future<void> init() async {
-    Future.wait(
+    await Future.wait(
       [
         getMedicinesFilters(),
         getUserMedicinesList(page: 1, pageSize: 10),
@@ -135,6 +137,10 @@ class MedicineViewCubit extends Cubit<MedicineViewState> {
       emit(state.copyWith(
         requestStatus: RequestStatus.success,
         selectedMedicineDetails: response,
+        //* second source for the end date: the medicine record itself carries it
+        //* when one was set. Null is a no-op in copyWith, so whichever of this
+        //* and the status request answers with a date wins.
+        medicineEndDate: response.endDate,
       ));
     }, failure: (error) {
       emit(state.copyWith(requestStatus: RequestStatus.failure));
@@ -187,83 +193,114 @@ class MedicineViewCubit extends Cubit<MedicineViewState> {
   }
 
   Future<void> fetchMedicineActiveStatus(String medicineId) async {
-    emit(state.copyWith(isSwitchLoading: true, switchErrorMessage: ''));
+    safeEmit(state.copyWith(isSwitchLoading: true, switchErrorMessage: ''));
     final result = await _medicinesViewRepo.getMedicineActiveStatus(
       medicineId: medicineId,
       userType: 'Patient',
       language: AppStrings.arabicLang,
     );
     result.when(
-      success: (isActive) {
-        emit(
+      success: (status) {
+        safeEmit(
           state.copyWith(
             isSwitchLoading: false,
-            isActiveMedicine: isActive,
+            isStatusResolved: true,
+            isActiveMedicine: status.isActiveMedicine,
+            medicineEndDate: status.endDate,
           ),
         );
       },
       failure: (error) {
-        emit(state.copyWith(
-          isSwitchLoading: false,
-          switchErrorMessage: error.errors.first,
-        ));
+        //* isStatusResolved stays false: a failed fetch must never be shown as "ended".
+        safeEmit(
+          state.copyWith(
+            isSwitchLoading: false,
+            switchErrorMessage: error.errors.isNotEmpty
+                ? error.errors.first
+                : 'تعذر تحميل حالة استمرارية الدواء',
+          ),
+        );
       },
     );
   }
 
-  Future<void> updateMedicineActiveStatus(
-      String medicineId, bool isActive) async {
-    final originalState = state.isActiveMedicine;
-    emit(state.copyWith(isSwitchLoading: true, switchErrorMessage: ''));
+  /// Ends the medicine: calls UpdateMedicineStatus with `isActiveMedicine: false`
+  /// and the user-picked [endDate] ('yyyy-MM-dd') collected in the confirmation
+  /// dialog. The medicine is treated as ended, and its alarms cancelled, only
+  /// after the API confirms it. Returns true when the medicine is ended.
+  Future<bool> endMedicine({
+    required String medicineId,
+    required String endDate,
+  }) async {
+    if (state.isSwitchLoading) return false; //* re-entrancy guard
+    if (state.isStatusResolved && !state.isActiveMedicine) {
+      return false; //* already ended
+    }
 
-    final date = DateTime.now().toIso8601String().split('T').first;
+    //* alarms are keyed by medicine name, so capture it before awaiting
+    final medicineName = state.selectestMedicineDetails?.medicineName;
+
+    //* no optimistic flip: isActiveMedicine/medicineEndDate are written on success only
+    safeEmit(state.copyWith(isSwitchLoading: true, switchErrorMessage: ''));
 
     final result = await _medicinesViewRepo.updateMedicineStatus(
       medicineId: medicineId,
       userType: 'Patient',
       language: AppStrings.arabicLang,
-      isActiveMedicine: isActive,
-      date: date,
+      isActiveMedicine: false,
+      endDate: endDate,
     );
 
+    bool succeeded = false;
     result.when(
-      success: (newStatus) {
-        emit(
+      success: (status) {
+        succeeded = !status.isActiveMedicine;
+        safeEmit(
           state.copyWith(
             isSwitchLoading: false,
-            isActiveMedicine: newStatus,
+            isStatusResolved: true,
+            isActiveMedicine: status.isActiveMedicine,
+            medicineEndDate: status.endDate ?? endDate,
+            switchErrorMessage:
+                succeeded ? '' : 'تعذر إنهاء الدواء، حاول مرة أخرى',
           ),
         );
-        newStatus == false
-            ? cancelAlarmsCreatedBeforePerMedicine(
-                state.selectestMedicineDetails!.medicineName)
-            : null;
       },
       failure: (error) {
-        emit(
+        safeEmit(
           state.copyWith(
             isSwitchLoading: false,
-            isActiveMedicine: originalState,
-            switchErrorMessage: error.errors.first,
+            switchErrorMessage: error.errors.isNotEmpty
+                ? error.errors.first
+                : 'تعذر إنهاء الدواء، حاول مرة أخرى',
           ),
         );
-        cancelAlarmsCreatedBeforePerMedicine(
-            state.selectestMedicineDetails!.medicineName);
       },
     );
+
+    //* only reachable when the API confirmed the medicine is ended
+    if (succeeded && medicineName != null && medicineName.isNotEmpty) {
+      await cancelAlarmsCreatedBeforePerMedicine(medicineName);
+    }
+    return succeeded;
   }
 
   Future<void> cancelAlarmsCreatedBeforePerMedicine(String medicineName) async {
-    final alarmsId = getAlarmsForMedicine(medicineName);
-    for (final id in alarmsId) {
-      await Alarm.stop(id);
+    try {
+      final alarmsId = getAlarmsForMedicine(medicineName);
+      for (final id in alarmsId) {
+        await Alarm.stop(id);
+      }
+      await removeMedicineAlarms(medicineName);
+    } catch (error) {
+      //* a local alarm failure must not surface as a failed request
+      AppLogger.error('Failed to cancel alarms for $medicineName: $error');
     }
-    await removeMedicineAlarms(medicineName);
   }
 
   List<int> getAlarmsForMedicine(String medicineName) {
-    final box = Hive.box<List<MedicineAlarmModel>>(
-        MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
+    final box =
+        Hive.box(MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
 
     final medicineAlarms =
         List<MedicineAlarmModel>.from(box.get('medicines') ?? []);
@@ -279,8 +316,8 @@ class MedicineViewCubit extends Cubit<MedicineViewState> {
   }
 
   Future<void> removeMedicineAlarms(String medicineName) async {
-    final box = Hive.box<List<MedicineAlarmModel>>(
-        MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
+    final box =
+        Hive.box(MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
 
     final alarms = List<MedicineAlarmModel>.from(box.get('medicines') ?? []);
 

--- a/lib/features/medicine/medicine_view/logic/medicine_view_state.dart
+++ b/lib/features/medicine/medicine_view/logic/medicine_view_state.dart
@@ -13,6 +13,21 @@ class MedicineViewState extends Equatable {
   final bool isDeleteRequest;
   final bool isLoadingMore;
   final bool isActiveMedicine;
+
+  /// True once the medicine status API has answered at least once.
+  /// Needed because [isActiveMedicine] defaults to false, so without this flag
+  /// "status not loaded yet" and "medicine ended" are indistinguishable.
+  final bool isStatusResolved;
+
+  /// The medicine end date as 'yyyy-MM-dd'. Null means unknown (a legacy record,
+  /// or a fresh launch before the backend returns it).
+  ///
+  /// Note: both this field and [isStatusResolved] only ever move forward
+  /// (null -> date, false -> true) and there is no re-activation flow, so the
+  /// `x ?? this.x` copyWith idiom below is intentional — a null-clearing
+  /// sentinel is not needed. The cubit is a get_it factory, so every screen
+  /// starts again from [MedicineViewState.initial].
+  final String? medicineEndDate;
   final bool isSwitchLoading;
   final String switchErrorMessage;
   final ModuleGuidanceDataModel? moduleGuidanceData;
@@ -27,10 +42,23 @@ class MedicineViewState extends Equatable {
     this.isDeleteRequest = false,
     this.isLoadingMore = false,
     this.isActiveMedicine = false,
+    this.isStatusResolved = false,
+    this.medicineEndDate,
     this.isSwitchLoading = false,
     this.switchErrorMessage = '',
     this.moduleGuidanceData,
   });
+
+  /// The medicine is ended only when the status API said so.
+  bool get isMedicineEnded => isStatusResolved && !isActiveMedicine;
+
+  /// Ending requires a resolved active status and a loaded medicine (its name is
+  /// what the local alarms are keyed by).
+  bool get canEndMedicine =>
+      isStatusResolved &&
+      isActiveMedicine &&
+      !isSwitchLoading &&
+      selectestMedicineDetails != null;
 
   factory MedicineViewState.initial() {
     return MedicineViewState(
@@ -43,6 +71,8 @@ class MedicineViewState extends Equatable {
       isDeleteRequest: false,
       isLoadingMore: false,
       isActiveMedicine: false,
+      isStatusResolved: false,
+      medicineEndDate: null,
       isSwitchLoading: false,
       switchErrorMessage: '',
       moduleGuidanceData: null,
@@ -59,6 +89,8 @@ class MedicineViewState extends Equatable {
     bool? isDeleteRequest,
     bool? isLoadingMore,
     bool? isActiveMedicine,
+    bool? isStatusResolved,
+    String? medicineEndDate,
     bool? isSwitchLoading,
     String? switchErrorMessage,
     ModuleGuidanceDataModel? moduleGuidanceData,
@@ -74,6 +106,8 @@ class MedicineViewState extends Equatable {
       isDeleteRequest: isDeleteRequest ?? this.isDeleteRequest,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
       isActiveMedicine: isActiveMedicine ?? this.isActiveMedicine,
+      isStatusResolved: isStatusResolved ?? this.isStatusResolved,
+      medicineEndDate: medicineEndDate ?? this.medicineEndDate,
       isSwitchLoading: isSwitchLoading ?? this.isSwitchLoading,
       switchErrorMessage: switchErrorMessage ?? this.switchErrorMessage,
       moduleGuidanceData: moduleGuidanceData ?? this.moduleGuidanceData,
@@ -91,6 +125,8 @@ class MedicineViewState extends Equatable {
         isDeleteRequest,
         isLoadingMore,
         isActiveMedicine,
+        isStatusResolved,
+        medicineEndDate,
         isSwitchLoading,
         switchErrorMessage,
         moduleGuidanceData,

--- a/lib/features/medicine/medicine_view/widgets/end_medicine_confirmation_dialog.dart
+++ b/lib/features/medicine/medicine_view/widgets/end_medicine_confirmation_dialog.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:we_care/core/global/Helpers/functions.dart';
+import 'package:we_care/core/global/SharedWidgets/date_time_picker_widget.dart';
+import 'package:we_care/core/global/theming/app_text_styles.dart';
+import 'package:we_care/core/global/theming/color_manager.dart';
+
+/// Confirms ending a medicine and collects the medicine end date.
+///
+/// Returns the picked date as 'yyyy-MM-dd', or null when the user cancels or
+/// dismisses the dialog (in which case nothing should happen).
+///
+/// The end date cannot be in the future — [DateTimePickerContainer] already
+/// clamps its `lastDate` to today — and cannot be before [medicineStartDate].
+Future<String?> showEndMedicineConfirmationDialog({
+  required BuildContext context,
+  required String medicineName,
+  String? medicineStartDate,
+}) {
+  String? pickedEndDate;
+  String? validationError;
+
+  //* startDate may hold the app's "لم يتم ادخال بيانات" sentinel instead of a date,
+  //* in which case the "end >= start" rule is skipped rather than blocking the user.
+  final hasValidStartDate = medicineStartDate != null &&
+      RegExp(r'^\d{4}-\d{2}-\d{2}$').hasMatch(medicineStartDate);
+
+  return showDialog<String>(
+    context: context,
+    builder: (dialogContext) {
+      return StatefulBuilder(
+        builder: (dialogContext, setState) {
+          return AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(15.r),
+            ),
+            title: Text(
+              "تأكيد إنهاء الدواء",
+              textAlign: TextAlign.center,
+              style: AppTextStyles.font18blackWight500,
+            ),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'سيتم إنهاء "$medicineName" وإلغاء التنبيهات الخاصة به.',
+                    style: AppTextStyles.font14blackWeight400,
+                  ),
+                  verticalSpacing(16),
+                  Text(
+                    "تاريخ انتهاء الدواء",
+                    style: AppTextStyles.font14blackWeight400.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  verticalSpacing(10),
+                  DateTimePickerContainer(
+                    placeholderText: pickedEndDate ?? "يوم / شهر / سنة",
+                    //* deliberately Colors.red and not AppColorsManager.warningColor:
+                    //* the picker appends its own "required field" text for that exact
+                    //* color, which would duplicate the message shown below
+                    containerBorderColor: validationError == null
+                        ? AppColorsManager.textfieldOutsideBorderColor
+                        : Colors.red,
+                    onDateSelected: (date) {
+                      setState(
+                        () {
+                          //* both dates are yyyy-MM-dd, so comparing the strings
+                          //* is a correct chronological comparison
+                          if (hasValidStartDate &&
+                              date.compareTo(medicineStartDate) < 0) {
+                            pickedEndDate = null;
+                            validationError =
+                                "تاريخ الانتهاء يجب ألا يكون قبل تاريخ بدء الدواء ($medicineStartDate)";
+                          } else {
+                            pickedEndDate = date;
+                            validationError = null;
+                          }
+                        },
+                      );
+                    },
+                  ),
+                  if (validationError != null) ...[
+                    verticalSpacing(8),
+                    Text(
+                      validationError!,
+                      style: AppTextStyles.font14blackWeight400.copyWith(
+                        color: AppColorsManager.warningColor,
+                        fontSize: 12.sp,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(dialogContext),
+                child: Text(
+                  "إلغاء",
+                  style: AppTextStyles.font14blackWeight400
+                      .copyWith(color: Colors.red),
+                ),
+              ),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColorsManager.mainDarkBlue,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12.r),
+                  ),
+                ),
+                onPressed: pickedEndDate == null
+                    ? null
+                    : () => Navigator.pop(dialogContext, pickedEndDate),
+                child: Text(
+                  "تأكيد",
+                  style: AppTextStyles.font16DarkGreyWeight400.copyWith(
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      );
+    },
+  );
+}

--- a/lib/features/medicine/medicine_view/widgets/medicine_active_status_switch.dart
+++ b/lib/features/medicine/medicine_view/widgets/medicine_active_status_switch.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:we_care/core/global/Helpers/app_toasts.dart';
+import 'package:we_care/core/global/SharedWidgets/details_view_info_tile.dart';
 import 'package:we_care/core/global/theming/app_text_styles.dart';
 import 'package:we_care/core/global/theming/color_manager.dart';
 import 'package:we_care/features/medicine/medicine_view/logic/medicine_view_cubit.dart';
 import 'package:we_care/features/medicine/medicine_view/logic/medicine_view_state.dart';
+import 'package:we_care/features/medicine/medicine_view/widgets/end_medicine_confirmation_dialog.dart';
 
 class MedicineActiveStatusSwitch extends StatelessWidget {
   final String medicineId;
@@ -19,63 +22,138 @@ class MedicineActiveStatusSwitch extends StatelessWidget {
     return BlocBuilder<MedicineViewCubit, MedicineViewState>(
       buildWhen: (previous, current) =>
           previous.isActiveMedicine != current.isActiveMedicine ||
-          previous.isSwitchLoading != current.isSwitchLoading,
+          previous.isSwitchLoading != current.isSwitchLoading ||
+          previous.isStatusResolved != current.isStatusResolved ||
+          previous.medicineEndDate != current.medicineEndDate ||
+          //* canEndMedicine depends on the loaded medicine, which arrives from a
+          //* separate request than the status
+          previous.selectestMedicineDetails != current.selectestMedicineDetails,
       builder: (context, state) {
-        return Container(
-          padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
-          margin: EdgeInsets.only(bottom: 16.h),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(12.r),
-            border:
-                Border.all(color: AppColorsManager.mainDarkBlue, width: 0.3),
-            gradient: const LinearGradient(
-              colors: [Color(0xFFECF5FF), Color(0xFFFBFDFD)],
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-            ),
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'حالة استمرارية الدواء',
-                style: AppTextStyles.font16DarkGreyWeight400.copyWith(
-                  fontSize: 15.sp,
-                  color: AppColorsManager.mainDarkBlue,
-                  fontWeight: FontWeight.w600,
+        return Column(
+          children: [
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
+              margin: EdgeInsets.only(bottom: 16.h),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12.r),
+                border: Border.all(
+                    color: AppColorsManager.mainDarkBlue, width: 0.3),
+                gradient: const LinearGradient(
+                  colors: [Color(0xFFECF5FF), Color(0xFFFBFDFD)],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
                 ),
               ),
-              Row(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  if (state.isSwitchLoading)
-                    Padding(
-                      padding: EdgeInsets.only(left: 8.w),
-                      child: SizedBox(
-                        width: 20.w,
-                        height: 20.h,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2.w,
-                          color: AppColorsManager.mainDarkBlue,
-                        ),
-                      ),
+                  Text(
+                    'حالة استمرارية الدواء',
+                    style: AppTextStyles.font16DarkGreyWeight400.copyWith(
+                      fontSize: 15.sp,
+                      color: AppColorsManager.mainDarkBlue,
+                      fontWeight: FontWeight.w600,
                     ),
-                  Switch.adaptive(
-                    activeColor: AppColorsManager.mainDarkBlue,
-                    value: state.isActiveMedicine,
-                    onChanged: state.isSwitchLoading
-                        ? null
-                        : (value) {
-                            context
-                                .read<MedicineViewCubit>()
-                                .updateMedicineActiveStatus(medicineId, value);
-                          },
                   ),
+                  _buildStatusControl(context, state),
                 ],
               ),
-            ],
-          ),
+            ),
+
+            /// An ended medicine shows its end date; the tile hides itself when
+            /// the date is unknown (legacy records / before the API returns it).
+            if (state.isMedicineEnded)
+              DetailsViewInfoTile(
+                title: 'تاريخ انتهاء الدواء',
+                value: state.medicineEndDate ?? '',
+                icon: 'assets/images/date_icon.png',
+                isExpanded: true,
+              ),
+          ],
         );
       },
     );
+  }
+
+  Widget _buildStatusControl(BuildContext context, MedicineViewState state) {
+    if (state.isSwitchLoading) {
+      return Padding(
+        padding: EdgeInsets.only(left: 8.w),
+        child: SizedBox(
+          width: 20.w,
+          height: 20.h,
+          child: CircularProgressIndicator(
+            strokeWidth: 2.w,
+            color: AppColorsManager.mainDarkBlue,
+          ),
+        ),
+      );
+    }
+
+    /// The status is not known yet (still loading, or the request failed) — a
+    /// failed request must never be presented as an ended medicine.
+    if (!state.isStatusResolved) {
+      return Text(
+        '—',
+        style: AppTextStyles.font16DarkGreyWeight400.copyWith(
+          color: AppColorsManager.mainDarkBlue,
+        ),
+      );
+    }
+
+    /// Ended: read-only, and there is no way back — restarting the medicine or
+    /// changing its dose is a brand new medicine record.
+    if (!state.isActiveMedicine) {
+      return Text(
+        'منتهي',
+        style: AppTextStyles.font16DarkGreyWeight400.copyWith(
+          fontSize: 15.sp,
+          color: AppColorsManager.warningColor,
+          fontWeight: FontWeight.w600,
+        ),
+      );
+    }
+
+    return Switch.adaptive(
+      activeColor: AppColorsManager.mainDarkBlue,
+      value: true,
+      onChanged: state.canEndMedicine
+          ? (value) async => _onStatusToggled(context, value)
+          : null,
+    );
+  }
+
+  Future<void> _onStatusToggled(BuildContext context, bool value) async {
+    if (value) return; //* only turning the status off ends a medicine
+
+    final cubit = context.read<MedicineViewCubit>();
+    final medicine = cubit.state.selectestMedicineDetails;
+    if (medicine == null) return;
+
+    final endDate = await showEndMedicineConfirmationDialog(
+      context: context,
+      medicineName: medicine.medicineName,
+      medicineStartDate: medicine.startDate,
+    );
+
+    //* cancelled or dismissed: no request, no state change, alarms untouched
+    if (endDate == null) return;
+
+    final isEnded = await cubit.endMedicine(
+      medicineId: medicineId,
+      endDate: endDate,
+    );
+
+    //* showSuccess/showError are Fluttertoast based and take no BuildContext
+    if (isEnded) {
+      await showSuccess('تم إنهاء الدواء بنجاح');
+    } else {
+      final errorMessage = cubit.state.switchErrorMessage;
+      await showError(
+        errorMessage.isEmpty
+            ? 'تعذر إنهاء الدواء، حاول مرة أخرى'
+            : errorMessage,
+      );
+    }
   }
 }

--- a/lib/features/medicine/medicines_api_constants.dart
+++ b/lib/features/medicine/medicines_api_constants.dart
@@ -43,6 +43,8 @@ class MedicinesApiConstants {
 
   static const getMedicineActiveStatus =
       "MedicineUserEntryPage/GetMedicineActiveStatus";
+  /// PUT body: `{ "endDate": 'yyyy-MM-dd', "isActiveMedicine": bool }`.
+  /// The response echoes the same `endDate` / `isActiveMedicine` pair.
   static const updateMedicineStatus =
       "MedicineUserEntryPage/UpdateMedicineStatus";
 

--- a/lib/features/medicine/medicines_data_entry/Presentation/views/alarm/alarm_demo/screens/edit_alarm.dart
+++ b/lib/features/medicine/medicines_data_entry/Presentation/views/alarm/alarm_demo/screens/edit_alarm.dart
@@ -247,8 +247,8 @@ class _AlarmEditScreenState extends State<AlarmEditScreen> {
   }
 
   Future<void> saveAlarmsCreatedPerMedicineInLocalStorage() async {
-    final box = Hive.box<List<MedicineAlarmModel>>(
-        MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
+    final box =
+        Hive.box(MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
 
     // Read existing alarms safely (empty list if box has no data)
     final existingAlarms =

--- a/lib/features/medicine/medicines_data_entry/logic/cubit/medicines_data_entry_cubit.dart
+++ b/lib/features/medicine/medicines_data_entry/logic/cubit/medicines_data_entry_cubit.dart
@@ -75,7 +75,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
     //   ),
     // );
     //!listen to ui using listner to navigate to MedicineAlarmRingingScreen using state.ringingAlarm
-    emit(
+    safeEmit(
       state.copyWith(
         ringingAlarm: alarms.alarms.first,
       ),
@@ -84,13 +84,13 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   Future<void> fetchNewMedicalCompitabilitySystemPrompt() async {
-    emit(state.copyWith(fetchSystemPromptStatus: RequestStatus.loading));
+    safeEmit(state.copyWith(fetchSystemPromptStatus: RequestStatus.loading));
 
     final result =
         await _medicinesDataEntryRepo.fetchMedicalCompitabilitySystemPrompt();
     result.when(
       success: (prompt) {
-        emit(
+        safeEmit(
           state.copyWith(
             fetchSystemPromptStatus: RequestStatus.success,
             medicalCompitabilitySystemPrompt: prompt,
@@ -98,7 +98,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         );
       },
       failure: (failure) {
-        emit(
+        safeEmit(
           state.copyWith(
             fetchSystemPromptStatus: RequestStatus.failure,
             message: failure.errors.first,
@@ -112,7 +112,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   Future<void> analyzeMedicalCompatibility() async {
     try {
       // Start loading
-      emit(
+      safeEmit(
         state.copyWith(
           analyzeMedicalCompatibilityStatus: RequestStatus.loading,
         ),
@@ -120,7 +120,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
 
       /// check if profile exists
       if (state.userMedicalProfileHistory == null) {
-        emit(
+        safeEmit(
           state.copyWith(
             analyzeMedicalCompatibilityStatus: RequestStatus.failure,
             message: "تعذر تحميل الملف الطبي للمريض، يرجى المحاولة مرة أخرى",
@@ -145,30 +145,16 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
 
       // if (analysis != null) {
 
-      emit(
+      safeEmit(
         state.copyWith(
           analyzeMedicalCompatibilityStatus: RequestStatus.success,
           compatibilityAnalysis: analysis,
-          // compatibilityAnalysis: CompatibilityAnalysisModel(
-          //   analysisSummary:
-          //       "تم تحليل التوافق بين الدواء الجديد والملف الطبي للمريض. تم اكتشاف بعض التداخلات الدوائية التي تتطلب الانتباه والمتابعة مع الطبيب.",
-          //   issues: [
-          //     CompatibilityIssue(
-          //       riskLevel: "L1",
-          //       title: "تداخل دوائي خطير مع مميعات الدم",
-          //       scientificReason:
-          //           "الدواء الجديد قد يزيد من تأثير مميعات الدم مثل الوارفارين مما قد يؤدي إلى زيادة خطر النزيف الحاد.",
-          //       doctorQuestion:
-          //           "هل يجب إيقاف أحد الدواءين أو تعديل الجرعة لتقليل خطر النزيف؟",
-          //     ),
-          //          ]
-          //    );
         ),
       );
       // }
     } catch (e) {
       AppLogger.error('Error in analyzeMedicalCompatibility: $e');
-      emit(
+      safeEmit(
         state.copyWith(
           analyzeMedicalCompatibilityStatus: RequestStatus.failure,
           message: 'حدث خطأ أثناء تحليل التوافق الدوائي $e',
@@ -178,7 +164,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   Future<void> getUserMedicalHistoryDetails() async {
-    emit(state.copyWith(
+    safeEmit(state.copyWith(
       medicalHistoryStatus: RequestStatus.loading,
     ));
 
@@ -187,7 +173,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
 
     response.when(
       success: (userMedicalProfileHistory) {
-        emit(
+        safeEmit(
           state.copyWith(
             userMedicalProfileHistory: userMedicalProfileHistory,
             medicalHistoryStatus: RequestStatus.success,
@@ -195,7 +181,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         );
       },
       failure: (failure) {
-        emit(
+        safeEmit(
           state.copyWith(
             userMedicalProfileHistory: null,
             medicalHistoryStatus: RequestStatus.failure,
@@ -211,13 +197,13 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
       final medicalComplaintBox =
           Hive.box<MedicalComplaint>("medical_complaints");
       medicalComplaints = medicalComplaintBox.values.toList(growable: true);
-      emit(
+      safeEmit(
         state.copyWith(
           medicalComplaints: medicalComplaints,
         ),
       );
     } catch (e) {
-      emit(
+      safeEmit(
         state.copyWith(
           medicalComplaints: [],
           message: e.toString(),
@@ -231,9 +217,10 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   ) async {
     await storeTempUserPastComplaints(pastDataEntered.mainSymptoms);
 
-    emit(
+    safeEmit(
       state.copyWith(
         medicineStartDate: pastDataEntered.startDate,
+        medicineEndDate: pastDataEntered.endDate,
         selectedMedicineName: pastDataEntered.medicineName,
         selectedMedicalForm: pastDataEntered.usageMethod,
         selectedNoOfDose: pastDataEntered.dosageFrequency,
@@ -287,7 +274,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   Future<void> submitEditsForMedicine() async {
-    emit(
+    safeEmit(
       state.copyWith(
         medicinesDataEntryStatus: RequestStatus.loading,
       ),
@@ -298,6 +285,8 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
       requestBody: MedicineDataEntryRequestBody(
         selectedDoseAmount: state.selectedDoseAmount!,
         startDate: state.medicineStartDate!,
+        //* optional: stays null unless the user picked an end date
+        endDate: state.medicineEndDate,
         medicineName: state.selectedMedicineName!,
         usageMethod: state.selectedMedicalForm!,
         dosageFrequency: state.selectedNoOfDose!,
@@ -316,7 +305,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
 
     response.when(
       success: (successMessage) {
-        emit(
+        safeEmit(
           state.copyWith(
             medicinesDataEntryStatus: RequestStatus.success,
             message: successMessage,
@@ -324,7 +313,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         );
       },
       failure: (error) {
-        emit(
+        safeEmit(
           state.copyWith(
             medicinesDataEntryStatus: RequestStatus.failure,
             message: error.errors.first,
@@ -420,7 +409,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   void getMedcineIdByName(String selectedMedicineName) {
     for (final medcineInfo in state.medicinesBasicInfo!) {
       if (medcineInfo.tradeName == selectedMedicineName) {
-        emit(
+        safeEmit(
           state.copyWith(
             medicineId: medcineInfo.id,
           ),
@@ -431,7 +420,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   Future<void> emitMedicineforms() async {
-    emit(
+    safeEmit(
       state.copyWith(
         medicalFormsOptionsLoadingState: OptionsLoadingState.loading,
       ),
@@ -443,7 +432,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
     );
     response.when(
       success: (response) {
-        emit(
+        safeEmit(
           state.copyWith(
             medicineForms: response,
             medicalFormsOptionsLoadingState: OptionsLoadingState.loaded,
@@ -451,7 +440,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         );
       },
       failure: (error) {
-        emit(
+        safeEmit(
           state.copyWith(
             message: error.errors.first,
             medicalFormsOptionsLoadingState: OptionsLoadingState.error,
@@ -462,7 +451,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   Future<void> emitMedcineDosesByForms() async {
-    emit(
+    safeEmit(
       state.copyWith(
         medicalDosesOptionsLoadingState: OptionsLoadingState.loading,
       ),
@@ -475,7 +464,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
     );
     response.when(
       success: (response) {
-        emit(
+        safeEmit(
           state.copyWith(
             medicalDoses: response,
             medicalDosesOptionsLoadingState: OptionsLoadingState.loaded,
@@ -483,7 +472,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         );
       },
       failure: (error) {
-        emit(
+        safeEmit(
           state.copyWith(
             message: error.errors.first,
             medicalDosesOptionsLoadingState: OptionsLoadingState.error,
@@ -578,7 +567,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   Future<void> emitAllDurationsForCategory() async {
-    emit(
+    safeEmit(
       state.copyWith(
         allDurationsBasedOnCategoryOptionsLoadingState:
             OptionsLoadingState.loading,
@@ -591,7 +580,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
     );
     response.when(
       success: (response) {
-        emit(
+        safeEmit(
           state.copyWith(
             allDurationsBasedOnCategory: response,
             allDurationsBasedOnCategoryOptionsLoadingState:
@@ -600,7 +589,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         );
       },
       failure: (error) {
-        emit(
+        safeEmit(
           state.copyWith(
             message: error.errors.first,
             allDurationsBasedOnCategoryOptionsLoadingState:
@@ -612,7 +601,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   Future<void> postMedicinesDataEntry(S locale) async {
-    emit(
+    safeEmit(
       state.copyWith(
         medicinesDataEntryStatus: RequestStatus.loading,
       ),
@@ -622,6 +611,8 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
       requestBody: MedicineDataEntryRequestBody(
         selectedDoseAmount: state.selectedDoseAmount!,
         startDate: state.medicineStartDate!,
+        //* optional: stays null unless the user picked an end date
+        endDate: state.medicineEndDate,
         medicineName: state.selectedMedicineName!,
         usageMethod: state.selectedMedicalForm!,
         dosageFrequency: state.selectedNoOfDose!,
@@ -641,7 +632,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
     );
     response.when(
       success: (successMessage) {
-        emit(
+        safeEmit(
           state.copyWith(
             message: successMessage,
             medicinesDataEntryStatus: RequestStatus.success,
@@ -649,7 +640,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         );
       },
       failure: (error) {
-        emit(
+        safeEmit(
           state.copyWith(
             message: error.errors.first,
             medicinesDataEntryStatus: RequestStatus.failure,
@@ -674,7 +665,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
           Hive.box<MedicalComplaint>("medical_complaints");
       await medicalComplaintBox.clear();
     } catch (e) {
-      emit(
+      safeEmit(
         state.copyWith(
           message: e.toString(),
         ),
@@ -858,7 +849,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   void updateSelectedAlarmTime(String? alarmTime) {
-    emit(
+    safeEmit(
       state.copyWith(
         selectedAlarmTime: alarmTime,
       ),
@@ -867,13 +858,18 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
 
   /// Update Field Values
   void updateStartMedicineDate(String? date) {
-    emit(state.copyWith(medicineStartDate: date));
+    safeEmit(state.copyWith(medicineStartDate: date));
     validateRequiredFields();
     validateRequiredFieldsForAddNewMedicineInChronicDiseaseModule();
   }
 
+  /// Optional field, so it is deliberately left out of the form validations.
+  void updateEndMedicineDate(String? date) {
+    safeEmit(state.copyWith(medicineEndDate: date));
+  }
+
   Future<void> updateSelectedMedicineName(String? medicineName) async {
-    emit(state.copyWith(selectedMedicineName: medicineName));
+    safeEmit(state.copyWith(selectedMedicineName: medicineName));
     validateRequiredFields();
     validateRequiredFieldsForAddNewMedicineInChronicDiseaseModule();
     validateRequiredFieldsForMedicationCompatibility();
@@ -882,7 +878,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   Future<void> updateSelectedMedicalForm(String? form) async {
-    emit(state.copyWith(selectedMedicalForm: form));
+    safeEmit(state.copyWith(selectedMedicalForm: form));
     await Future.wait([
       emitMedcineDosesByForms(),
       emitAllDoseAmounts(),
@@ -895,21 +891,21 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
 
   //! Recheck this once more
   void updateSelectedDose(String? dose) {
-    emit(state.copyWith(selectedDose: dose));
+    safeEmit(state.copyWith(selectedDose: dose));
     // validateRequiredFields();
     validateRequiredFieldsForAddNewMedicineInChronicDiseaseModule();
     validateRequiredFieldsForMedicationCompatibility();
   }
 
   void updateSelectedDoseFrequency(String? noOfDose) {
-    emit(state.copyWith(selectedNoOfDose: noOfDose));
+    safeEmit(state.copyWith(selectedNoOfDose: noOfDose));
     validateRequiredFields();
     validateRequiredFieldsForAddNewMedicineInChronicDiseaseModule();
     validateRequiredFieldsForMedicationCompatibility();
   }
 
   void updateSelectedChronicDisease(String? val) {
-    emit(state.copyWith(selectedChronicDiseaseName: val));
+    safeEmit(state.copyWith(selectedChronicDiseaseName: val));
   }
 
   Future<void> getChronicDiseasesNames() async {
@@ -936,14 +932,14 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   void updateSelectedDoseAmount(String? doseAmount) {
-    emit(state.copyWith(selectedDoseAmount: doseAmount));
+    safeEmit(state.copyWith(selectedDoseAmount: doseAmount));
     validateRequiredFields();
     validateRequiredFieldsForAddNewMedicineInChronicDiseaseModule();
     validateRequiredFieldsForMedicationCompatibility();
   }
 
   Future<void> emitAllDoseAmounts() async {
-    emit(
+    safeEmit(
       state.copyWith(
         dosageAmountOptionsLoadingState: OptionsLoadingState.loading,
       ),
@@ -955,7 +951,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
     );
     response.when(
       success: (response) {
-        emit(
+        safeEmit(
           state.copyWith(
             dosageAmounts: response,
             dosageAmountOptionsLoadingState: OptionsLoadingState.loaded,
@@ -963,7 +959,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         );
       },
       failure: (error) {
-        emit(
+        safeEmit(
           state.copyWith(
             message: error.errors.first,
             dosageAmountOptionsLoadingState: OptionsLoadingState.error,
@@ -974,20 +970,20 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
   }
 
   Future<void> updateSelectedDoseDuration(String? doseDuration) async {
-    emit(state.copyWith(doseDuration: doseDuration));
+    safeEmit(state.copyWith(doseDuration: doseDuration));
     await emitAllDurationsForCategory();
     validateRequiredFields();
     validateRequiredFieldsForMedicationCompatibility();
   }
 
   void updateSelectedTimePeriod(String? timePeriods) {
-    emit(state.copyWith(timePeriods: timePeriods));
+    safeEmit(state.copyWith(timePeriods: timePeriods));
     validateRequiredFields();
     validateRequiredFieldsForMedicationCompatibility();
   }
 
   void updateSelectedDoctorName(String? value) {
-    emit(state.copyWith(selectedDoctorName: value));
+    safeEmit(state.copyWith(selectedDoctorName: value));
   }
 
   void validateRequiredFields() {
@@ -998,13 +994,13 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         state.doseDuration == null ||
         state.timePeriods == null ||
         state.selectedDoseAmount == null) {
-      emit(
+      safeEmit(
         state.copyWith(
           isFormValidated: false,
         ),
       );
     } else {
-      emit(
+      safeEmit(
         state.copyWith(
           isFormValidated: true,
         ),
@@ -1021,13 +1017,13 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         state.selectedDoseAmount == null ||
         state.userMedicalProfileHistory == null ||
         state.userMedicalProfileHistory!.isHistoryEmpty) {
-      emit(
+      safeEmit(
         state.copyWith(
           isMedicationCompatibilityFormValidated: false,
         ),
       );
     } else {
-      emit(
+      safeEmit(
         state.copyWith(
           isMedicationCompatibilityFormValidated: true,
         ),
@@ -1048,7 +1044,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
 
     await addedNewMedicineBox.add(newMedicalComplaint);
 
-    emit(
+    safeEmit(
       state.copyWith(
         isNewMedicineAddedSuccefuly: true,
       ),
@@ -1073,13 +1069,13 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         updatedMedicine,
       );
 
-      emit(
+      safeEmit(
         state.copyWith(
           isEditingNewMedicineSuccess: true,
         ),
       );
     } else {
-      emit(
+      safeEmit(
         state.copyWith(
           isEditingNewMedicineSuccess: false,
         ),
@@ -1095,13 +1091,13 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
         state.selectedDose == null ||
         state.selectedNoOfDose == null) {
       //! check for this later is there is aneed to add selectedDoseAmount here in this validation or no
-      emit(
+      safeEmit(
         state.copyWith(
           isAddNewMedicineFormValidated: false,
         ),
       );
     } else {
-      emit(
+      safeEmit(
         state.copyWith(
           isAddNewMedicineFormValidated: true,
         ),
@@ -1111,7 +1107,7 @@ class MedicinesDataEntryCubit extends Cubit<MedicinesDataEntryState>
 
   Future<void> loadMedicineDetailsViewForEditing(
       AddNewMedicineModel model) async {
-    emit(
+    safeEmit(
       state.copyWith(
         isEditingAddedMedicine: true,
         medicineStartDate: model.startDate,

--- a/lib/features/medicine/medicines_data_entry/logic/cubit/medicines_data_entry_state.dart
+++ b/lib/features/medicine/medicines_data_entry/logic/cubit/medicines_data_entry_state.dart
@@ -19,6 +19,10 @@ class MedicinesDataEntryState extends Equatable {
   final UserMedicalHistoryDetailsModel? userMedicalProfileHistory;
   final CompatibilityAnalysisModel? compatibilityAnalysis;
   final String? medicineStartDate;
+
+  /// Optional: set only when the user already knows when the medicine ends.
+  /// Normally a medicine is ended later from the medicine details screen.
+  final String? medicineEndDate;
   final String? selectedMedicineName;
   final String? selectedMedicalForm;
   final String? selectedDose;
@@ -80,6 +84,7 @@ class MedicinesDataEntryState extends Equatable {
     this.message = '',
     this.isEditMode = false,
     this.medicineStartDate,
+    this.medicineEndDate,
     this.selectedMedicineName,
     this.selectedMedicalForm,
     this.selectedDose,
@@ -134,6 +139,7 @@ class MedicinesDataEntryState extends Equatable {
           message: '',
           isEditMode: false,
           medicineStartDate: null,
+          medicineEndDate: null,
           selectedMedicineName: null,
           selectedMedicalForm: null,
           selectedDose: null,
@@ -187,6 +193,7 @@ class MedicinesDataEntryState extends Equatable {
     String? message,
     bool? isEditMode,
     String? medicineStartDate,
+    String? medicineEndDate,
     String? selectedMedicineName,
     String? selectedMedicalForm,
     String? selectedDose,
@@ -251,6 +258,7 @@ class MedicinesDataEntryState extends Equatable {
       message: message ?? this.message,
       isEditMode: isEditMode ?? this.isEditMode,
       medicineStartDate: medicineStartDate ?? this.medicineStartDate,
+      medicineEndDate: medicineEndDate ?? this.medicineEndDate,
       selectedMedicineName: selectedMedicineName ?? this.selectedMedicineName,
       selectedMedicalForm: selectedMedicalForm ?? this.selectedMedicalForm,
       selectedDose: selectedDose ?? this.selectedDose,
@@ -317,6 +325,7 @@ class MedicinesDataEntryState extends Equatable {
         message,
         isEditMode,
         medicineStartDate,
+        medicineEndDate,
         selectedMedicineName,
         selectedMedicalForm,
         selectedDose,

--- a/lib/features/medicine/scheduled_medicines/logic/scheduled_medicines_list_cubit.dart
+++ b/lib/features/medicine/scheduled_medicines/logic/scheduled_medicines_list_cubit.dart
@@ -13,8 +13,8 @@ class ScheduledMedicinesListCubit extends Cubit<ScheduledMedicinesListState> {
 
   /// Safely reads all medicine alarms from Hive using a stable key.
   List<MedicineAlarmModel> _getAllAlarms() {
-    final box = Hive.box<List<MedicineAlarmModel>>(
-        MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
+    final box =
+        Hive.box(MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
     return List<MedicineAlarmModel>.from(box.get('medicines') ?? []);
   }
 
@@ -77,8 +77,8 @@ class ScheduledMedicinesListCubit extends Cubit<ScheduledMedicinesListState> {
   }
 
   Future<void> _removeMedicineAlarms(String medicineName) async {
-    final box = Hive.box<List<MedicineAlarmModel>>(
-        MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
+    final box =
+        Hive.box(MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
 
     final alarms = _getAllAlarms();
     alarms.removeWhere((model) => model.medicineName == medicineName);

--- a/lib/features/medicine/shared/widgets/custom_alarm_button.dart
+++ b/lib/features/medicine/shared/widgets/custom_alarm_button.dart
@@ -148,8 +148,8 @@ class CustomAlarmButtonState extends State<CustomAlarmButton> {
   }
 
   List<int> getAlarmsForMedicine(String medicineName) {
-    final box = Hive.box<List<MedicineAlarmModel>>(
-        MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
+    final box =
+        Hive.box(MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
 
     final medicineAlarms =
         List<MedicineAlarmModel>.from(box.get('medicines') ?? []);
@@ -167,8 +167,8 @@ class CustomAlarmButtonState extends State<CustomAlarmButton> {
   }
 
   Future<void> removeMedicineAlarms(String medicineName) async {
-    final box = Hive.box<List<MedicineAlarmModel>>(
-        MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
+    final box =
+        Hive.box(MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
 
     final alarms = List<MedicineAlarmModel>.from(box.get('medicines') ?? []);
 

--- a/lib/features/medicine/shared/widgets/medicine_form_fields_widget.dart
+++ b/lib/features/medicine/shared/widgets/medicine_form_fields_widget.dart
@@ -56,6 +56,23 @@ class _MedicinesDataEntryFormFieldsWidgetState
               },
             ),
             verticalSpacing(16),
+            Text(
+              "تاريخ إنتهاء الدواء",
+              style: AppTextStyles.font18blackWight500,
+            ),
+            verticalSpacing(10),
+            DateTimePickerContainer(
+              //* optional field: no warning border when empty
+              placeholderText: state.medicineEndDate ?? "يوم / شهر / سنة",
+              //* cannot end before it started
+              firstDate: _endDateLowerBound(state.medicineStartDate),
+              onDateSelected: (pickedDate) {
+                context
+                    .read<MedicinesDataEntryCubit>()
+                    .updateEndMedicineDate(pickedDate);
+              },
+            ),
+            verticalSpacing(16),
             UserSelectionContainer(
               isEditMode: state.isEditMode,
               containerBorderColor: state.selectedMedicineName == null
@@ -291,6 +308,18 @@ class _MedicinesDataEntryFormFieldsWidgetState
         );
       },
     );
+  }
+
+  /// Earliest date selectable as the medicine end date: the day the medicine
+  /// started. Returns null when the start date is unset, is not a real date
+  /// (the app's "no data entered" placeholder), or is in the future — the
+  /// picker's last selectable date is today, and a lower bound after it would
+  /// assert.
+  DateTime? _endDateLowerBound(String? startDate) {
+    if (startDate == null || startDate.isEmpty) return null;
+    final parsed = DateTime.tryParse(startDate);
+    if (parsed == null || parsed.isAfter(DateTime.now())) return null;
+    return parsed;
   }
 
   Widget buildAddNewComplainButtonBlocBuilder() {

--- a/lib/features/nutration/nutration_data_entry/logic/deep_seek_services.dart
+++ b/lib/features/nutration/nutration_data_entry/logic/deep_seek_services.dart
@@ -913,6 +913,8 @@ L5 - Cautionary
     required String duration,
     UserMedicalHistoryDetailsModel? medicalProfile,
   }) {
+    final profileJson = medicalProfile?.toJson();
+
     return '''
 أنا الآن بصدد تناول دواء جديد.
 
@@ -926,7 +928,7 @@ L5 - Cautionary
 
 الملف الطبي للمريض:
 
-${medicalProfile?.toJson()}
+$profileJson
 
 قم بإجراء تحليل توافق شامل.
 ''';

--- a/lib/features/prescription/Presentation_view/views/prescription_view.dart
+++ b/lib/features/prescription/Presentation_view/views/prescription_view.dart
@@ -405,7 +405,7 @@ class PrescriptionCardITem extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            'المرض :',
+                            'التشخيص :',
                             style: AppTextStyles.font14BlueWeight700.copyWith(
                               fontSize: 14.sp,
                             ),

--- a/lib/features/show_data_entry_types/Data/Models/all_categories_tickets_count.dart
+++ b/lib/features/show_data_entry_types/Data/Models/all_categories_tickets_count.dart
@@ -26,15 +26,40 @@ class CategoriesTicketsCount {
   int medicine;
   int vaccine;
   int predescription;
+  int teeth;
+  int allergies;
+  int chronicDiseases;
+  int eyes;
+  int mentalHealth;
+  int sportsActivities;
+  int nutrition;
+  int vitalActivities;
+  int geneticDiseases;
+  int monthlyHealthSurvey;
+  int supplements;
+  int riskBehaviors;
 
-  CategoriesTicketsCount(
-      {required this.labTest,
-      required this.surgery,
-      required this.emergency,
-      required this.radiology,
-      required this.medicine,
-      required this.vaccine,
-      required this.predescription});
+  CategoriesTicketsCount({
+    this.labTest = 0,
+    this.surgery = 0,
+    this.emergency = 0,
+    this.radiology = 0,
+    this.medicine = 0,
+    this.vaccine = 0,
+    this.predescription = 0,
+    this.riskBehaviors = 0,
+    this.teeth = 0,
+    this.allergies = 0,
+    this.chronicDiseases = 0,
+    this.eyes = 0,
+    this.mentalHealth = 0,
+    this.sportsActivities = 0,
+    this.nutrition = 0,
+    this.vitalActivities = 0,
+    this.geneticDiseases = 0,
+    this.monthlyHealthSurvey = 0,
+    this.supplements = 0,
+  });
   factory CategoriesTicketsCount.fromJson(Map<String, dynamic> json) =>
       _$CategoriesTicketsCountFromJson(json);
 }

--- a/lib/features/show_data_entry_types/Presentation/views/widgets/medical_categories_types_grid_view.dart
+++ b/lib/features/show_data_entry_types/Presentation/views/widgets/medical_categories_types_grid_view.dart
@@ -480,6 +480,16 @@ const Map<String, String> _arabicTitleToField = {
   "الأدوية": "medicine",
   "التطعيمات": "vaccine",
   "روشتة الأطباء": "predescription",
+  "الامراض\n المزمنه": "chronicDiseases",
+  "الأمراض\n الوراثيه": "geneticDiseases",
+  "الحساسية": "allergies",
+  "العيون": "eyes",
+  "الأسنان": "teeth",
+  "الأمراض\nالنفسية": "mentalHealth",
+  "المتابعه الغذائية": "nutrition",
+  "النشاط الرياضي": "sportsActivities",
+  "الفيتامينات و\nالمكملات الغذائية": "supplements",
+  "السلوكيات\nالخاطئة": "riskBehaviors",
 };
 
 int getCategoryCountByArabicTitle(
@@ -502,6 +512,26 @@ int getCategoryCountByArabicTitle(
       return countData.vaccine;
     case 'predescription':
       return countData.predescription;
+    case 'chronicDiseases':
+      return countData.chronicDiseases;
+    case 'geneticDiseases':
+      return countData.geneticDiseases;
+    case 'allergies':
+      return countData.allergies;
+    case 'eyes':
+      return countData.eyes;
+    case 'teeth':
+      return countData.teeth;
+    case 'mentalHealth':
+      return countData.mentalHealth;
+    case 'nutrition':
+      return countData.nutrition;
+    case 'sportsActivities':
+      return countData.sportsActivities;
+    case 'supplements':
+      return countData.supplements;
+    case 'riskBehaviors':
+      return countData.riskBehaviors;
     default:
       return 0;
   }

--- a/lib/features/surgeries/data/models/get_surgeries_filters_response_model.dart
+++ b/lib/features/surgeries/data/models/get_surgeries_filters_response_model.dart
@@ -5,11 +5,11 @@ part 'get_surgeries_filters_response_model.g.dart';
 @JsonSerializable()
 class GetSurgeriesFiltersResponseModel {
   List<int>? years;
-  List<String>? surgeryNames;
+  List<String>? surgeryRegion;
 
   GetSurgeriesFiltersResponseModel({
     this.years,
-    this.surgeryNames,
+    this.surgeryRegion,
   });
 
   factory GetSurgeriesFiltersResponseModel.fromJson(

--- a/lib/features/surgeries/data/repos/surgeries_repo.dart
+++ b/lib/features/surgeries/data/repos/surgeries_repo.dart
@@ -59,11 +59,11 @@ class SurgeriesViewRepo {
   Future<ApiResult<GetUserSurgeriesResponseModal>> getFilteredSurgeries({
     required String language,
     int? year,
-    String? surgeryName,
+    String? surgeryRegion,
   }) async {
     try {
       final response = await surgeriesService.getFilteredSurgeries(
-          language, surgeryName, year);
+          language, surgeryRegion, year);
 
       return ApiResult.success(response);
     } catch (error) {

--- a/lib/features/surgeries/surgeries_data_entry_view/Presentation/views/surgeries_data_entry_view.dart
+++ b/lib/features/surgeries/surgeries_data_entry_view/Presentation/views/surgeries_data_entry_view.dart
@@ -4,6 +4,9 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:we_care/core/di/dependency_injection.dart';
 import 'package:we_care/core/global/Helpers/functions.dart';
 import 'package:we_care/core/global/SharedWidgets/custom_app_bar.dart';
+import 'package:we_care/core/global/SharedWidgets/module_guidance_alert_dialog.dart';
+import 'package:we_care/core/global/SharedWidgets/shared_app_bar_widget.dart';
+import 'package:we_care/core/global/theming/color_manager.dart';
 import 'package:we_care/features/surgeries/data/models/get_user_surgeries_response_model.dart';
 import 'package:we_care/features/surgeries/surgeries_data_entry_view/logic/cubit/surgery_data_entry_cubit.dart';
 
@@ -33,8 +36,46 @@ class SurgeriesDataEntryView extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                AppBarWithImageAndActionButtons(
-                  haveBackArrow: true,
+                BlocBuilder<SurgeryDataEntryCubit, SurgeryDataEntryState>(
+                  buildWhen: (previous, current) =>
+                      previous.moduleGuidanceData != current.moduleGuidanceData,
+                  builder: (context, state) {
+                    final guidance = state.moduleGuidanceData;
+                    final hasVideo = guidance?.videoLink?.isNotEmpty == true;
+                    final hasText =
+                        guidance?.moduleGuidanceText?.isNotEmpty == true;
+
+                    return AppBarWithImageAndActionButtons(
+                      haveBackArrow: true,
+                      trailingActions: [
+                        CircleIconButton(
+                          icon: Icons.play_arrow,
+                          color: hasVideo
+                              ? AppColorsManager.mainDarkBlue
+                              : Colors.grey,
+                          onTap: hasVideo
+                              ? () => launchYouTubeVideo(guidance!.videoLink)
+                              : null,
+                        ),
+                        SizedBox(width: 8.w),
+                        CircleIconButton(
+                          icon: Icons.menu_book_outlined,
+                          color: hasText
+                              ? AppColorsManager.mainDarkBlue
+                              : Colors.grey,
+                          onTap: hasText
+                              ? () {
+                                  ModuleGuidanceAlertDialog.show(
+                                    context,
+                                    title: "العمليات",
+                                    description: guidance!.moduleGuidanceText!,
+                                  );
+                                }
+                              : null,
+                        ),
+                      ],
+                    );
+                  },
                 ),
                 verticalSpacing(24),
                 SuergeriesDataEntryFormFields(),

--- a/lib/features/surgeries/surgeries_data_entry_view/logic/cubit/surgery_data_entry_cubit.dart
+++ b/lib/features/surgeries/surgeries_data_entry_view/logic/cubit/surgery_data_entry_cubit.dart
@@ -8,6 +8,7 @@ import 'package:we_care/core/global/Helpers/app_logger.dart';
 import 'package:we_care/core/global/Helpers/extensions.dart';
 import 'package:we_care/core/global/app_strings.dart';
 import 'package:we_care/core/global/shared_repo.dart';
+import 'package:we_care/core/models/module_guidance_response_model.dart';
 import 'package:we_care/features/surgeries/data/models/get_user_surgeries_response_model.dart';
 import 'package:we_care/features/surgeries/data/models/surgery_request_body_model.dart';
 import 'package:we_care/features/surgeries/data/repos/surgeries_data_entry_repo.dart';
@@ -135,11 +136,35 @@ class SurgeryDataEntryCubit extends Cubit<SurgeryDataEntryState> {
   }
 
   Future<void> intialRequestsForDataEntry() async {
+    await emitModuleGuidanceData();
     await emitGetAllSurgeriesRegions();
     await emitCountriesData();
     // await emitGetSurgeryStatus();
     await emitDoctorNames();
     await emitHospitalNames();
+  }
+
+  Future<void> emitModuleGuidanceData() async {
+    final response = await sharedRepo.getModuleGuidance(
+      WeCareMedicalModules.surgeriesDataEntry.name,
+    );
+
+    response.when(
+      success: (response) {
+        emit(
+          state.copyWith(
+            moduleGuidanceData: response,
+          ),
+        );
+      },
+      failure: (error) {
+        emit(
+          state.copyWith(
+            moduleGuidanceData: null,
+          ),
+        );
+      },
+    );
   }
 
   void removeUploadedReport(String url) {

--- a/lib/features/surgeries/surgeries_data_entry_view/logic/cubit/surgery_data_entry_state.dart
+++ b/lib/features/surgeries/surgeries_data_entry_view/logic/cubit/surgery_data_entry_state.dart
@@ -29,6 +29,7 @@ class SurgeryDataEntryState extends Equatable {
   final String? surgeonName;
   final String? selectedHospitalCenter;
   final String? internistName; // طبيب باطنه
+  final ModuleGuidanceDataModel? moduleGuidanceData;
 
   const SurgeryDataEntryState({
     this.surgeriesDataEntryStatus = RequestStatus.initial,
@@ -58,6 +59,7 @@ class SurgeryDataEntryState extends Equatable {
     this.internistName,
     this.doctorNames = const [],
     this.hospitals = const [],
+    this.moduleGuidanceData,
   }) : super();
 
   const SurgeryDataEntryState.initialState()
@@ -88,6 +90,7 @@ class SurgeryDataEntryState extends Equatable {
           internistName: null,
           doctorNames: const [],
           hospitals: const [],
+          moduleGuidanceData: null,
         );
 
   SurgeryDataEntryState copyWith({
@@ -118,6 +121,7 @@ class SurgeryDataEntryState extends Equatable {
     String? internistName,
     List<String>? doctorNames,
     List<String>? hospitals,
+    ModuleGuidanceDataModel? moduleGuidanceData,
   }) {
     return SurgeryDataEntryState(
       surgeriesDataEntryStatus:
@@ -153,6 +157,7 @@ class SurgeryDataEntryState extends Equatable {
       internistName: internistName ?? this.internistName,
       doctorNames: doctorNames ?? this.doctorNames,
       hospitals: hospitals ?? this.hospitals,
+      moduleGuidanceData: moduleGuidanceData ?? this.moduleGuidanceData,
     );
   }
 
@@ -185,5 +190,6 @@ class SurgeryDataEntryState extends Equatable {
         internistName,
         doctorNames,
         hospitals,
+        moduleGuidanceData,
       ];
 }

--- a/lib/features/surgeries/surgeries_services.dart
+++ b/lib/features/surgeries/surgeries_services.dart
@@ -87,7 +87,7 @@ abstract class SurgeriesService {
   @GET(SurgeriesApiConstants.getFilteredSurgeries)
   Future<GetUserSurgeriesResponseModal> getFilteredSurgeries(
       @Query("language") String language,
-      @Query("surgeryName") String? surgeryName,
+      @Query("surgeryRegion") String? surgeryRegion,
       @Query("year") int? year);
 
   @DELETE(SurgeriesApiConstants.deleteSurgeryById)

--- a/lib/features/surgeries/surgeries_view/logic/surgeries_view_cubit.dart
+++ b/lib/features/surgeries/surgeries_view/logic/surgeries_view_cubit.dart
@@ -80,7 +80,7 @@ class SurgeriesViewCubit extends Cubit<SurgeriesViewState> {
       emit(state.copyWith(
         requestStatus: RequestStatus.success,
         yearsFilter: response.years,
-        surgeryNameFilter: response.surgeryNames,
+        surgeryRegionFilter: response.surgeryRegion,
       ));
     }, failure: (error) {
       emit(state.copyWith(requestStatus: RequestStatus.failure));
@@ -122,11 +122,12 @@ class SurgeriesViewCubit extends Cubit<SurgeriesViewState> {
     });
   }
 
-  Future<void> getFilteredSurgeryList({int? year, String? surgeryName}) async {
+  Future<void> getFilteredSurgeryList(
+      {int? year, String? surgeryRegion}) async {
     emit(state.copyWith(requestStatus: RequestStatus.loading));
     final result = await _surgeriesViewRepo.getFilteredSurgeries(
       language: AppStrings.arabicLang,
-      surgeryName: surgeryName,
+      surgeryRegion: surgeryRegion,
       year: year,
     );
     result.when(success: (response) {

--- a/lib/features/surgeries/surgeries_view/logic/surgeries_view_state.dart
+++ b/lib/features/surgeries/surgeries_view/logic/surgeries_view_state.dart
@@ -9,7 +9,7 @@ class SurgeriesViewState extends Equatable {
   final List<SurgeryModel> userSurgeries;
   final SurgeryModel? selectedSurgeryDetails;
   final List<int> yearsFilter;
-  final List<String> surgeryNameFilter;
+  final List<String> surgeryRegionFilter;
   final bool isDeleteRequest;
   final bool isLoadingMore;
   final ModuleGuidanceDataModel? moduleGuidanceData;
@@ -18,7 +18,7 @@ class SurgeriesViewState extends Equatable {
     this.responseMessage = '',
     this.requestStatus = RequestStatus.initial,
     this.yearsFilter = const [],
-    this.surgeryNameFilter = const ['الكل'],
+    this.surgeryRegionFilter = const ['الكل'],
     this.userSurgeries = const [],
     this.selectedSurgeryDetails,
     this.isDeleteRequest = false,
@@ -31,7 +31,7 @@ class SurgeriesViewState extends Equatable {
       responseMessage: '',
       requestStatus: RequestStatus.initial,
       yearsFilter: const [],
-      surgeryNameFilter: const ['الكل'],
+      surgeryRegionFilter: const ['الكل'],
       userSurgeries: const [],
       selectedSurgeryDetails: null,
       isDeleteRequest: false,
@@ -44,7 +44,7 @@ class SurgeriesViewState extends Equatable {
     String? responseMessage,
     RequestStatus? requestStatus,
     List<int>? yearsFilter,
-    List<String>? surgeryNameFilter,
+    List<String>? surgeryRegionFilter,
     List<SurgeryModel>? userSurgeries,
     SurgeryModel? selectedSurgeryDetails,
     bool? isDeleteRequest,
@@ -55,7 +55,7 @@ class SurgeriesViewState extends Equatable {
       responseMessage: responseMessage ?? this.responseMessage,
       requestStatus: requestStatus ?? this.requestStatus,
       yearsFilter: yearsFilter ?? this.yearsFilter,
-      surgeryNameFilter: surgeryNameFilter ?? this.surgeryNameFilter,
+      surgeryRegionFilter: surgeryRegionFilter ?? this.surgeryRegionFilter,
       userSurgeries: userSurgeries ?? this.userSurgeries,
       selectedSurgeryDetails: selectedSurgeryDetails,
       isDeleteRequest: isDeleteRequest ?? this.isDeleteRequest,
@@ -69,7 +69,7 @@ class SurgeriesViewState extends Equatable {
         responseMessage,
         requestStatus,
         yearsFilter,
-        surgeryNameFilter,
+        surgeryRegionFilter,
         userSurgeries,
         selectedSurgeryDetails,
         isDeleteRequest,

--- a/lib/features/surgeries/surgeries_view/views/surgeries_view.dart
+++ b/lib/features/surgeries/surgeries_view/views/surgeries_view.dart
@@ -71,7 +71,7 @@ class SurgeriesView extends StatelessWidget {
               BlocBuilder<SurgeriesViewCubit, SurgeriesViewState>(
                 buildWhen: (previous, current) =>
                     previous.yearsFilter != current.yearsFilter ||
-                    previous.surgeryNameFilter != current.surgeryNameFilter,
+                    previous.surgeryRegionFilter != current.surgeryRegionFilter,
                 builder: (context, state) {
                   return DataViewFiltersRow(
                     filters: [
@@ -80,8 +80,8 @@ class SurgeriesView extends StatelessWidget {
                           options: state.yearsFilter,
                           isYearFilter: true),
                       FilterConfig(
-                        title: 'اسم العملية',
-                        options: state.surgeryNameFilter,
+                        title: 'العضو',
+                        options: state.surgeryRegionFilter,
                       ),
                     ],
                     onApply: (selectedFilters) {
@@ -89,12 +89,12 @@ class SurgeriesView extends StatelessWidget {
                       if (selectedFilters['السنة'] == null) {
                         BlocProvider.of<SurgeriesViewCubit>(context)
                             .getFilteredSurgeryList(
-                                surgeryName: selectedFilters['اسم العملية']);
+                                surgeryRegion: selectedFilters['العضو']);
                       }
                       BlocProvider.of<SurgeriesViewCubit>(context)
                           .getFilteredSurgeryList(
                               year: selectedFilters['السنة'],
-                              surgeryName: selectedFilters['اسم العملية']);
+                              surgeryRegion: selectedFilters['العضو']);
                     },
                   );
                 },

--- a/lib/features/test_laboratory/analysis_view/Presention/analysis_view.dart
+++ b/lib/features/test_laboratory/analysis_view/Presention/analysis_view.dart
@@ -76,7 +76,7 @@ class MedicalAnalysisView extends StatelessWidget {
                               ? () {
                                   ModuleGuidanceAlertDialog.show(
                                     context,
-                                    title: "القياسات الحيوية",
+                                    title: "التحاليل الطبية",
                                     description: state.moduleGuidanceData!
                                         .moduleGuidanceText!,
                                   );

--- a/lib/features/test_laboratory/test_analysis_data_entry/Presentation/views/test_analysis_data_entry_view.dart
+++ b/lib/features/test_laboratory/test_analysis_data_entry/Presentation/views/test_analysis_data_entry_view.dart
@@ -4,6 +4,9 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:we_care/core/di/dependency_injection.dart';
 import 'package:we_care/core/global/Helpers/functions.dart';
 import 'package:we_care/core/global/SharedWidgets/custom_app_bar.dart';
+import 'package:we_care/core/global/SharedWidgets/module_guidance_alert_dialog.dart';
+import 'package:we_care/core/global/SharedWidgets/shared_app_bar_widget.dart';
+import 'package:we_care/core/global/theming/color_manager.dart';
 import 'package:we_care/features/emergency_complaints/emergency_complaints_data_entry/logic/cubit/emergency_complaint_details_cubit.dart';
 import 'package:we_care/features/test_laboratory/data/models/get_analysis_by_id_response_model.dart';
 import 'package:we_care/features/test_laboratory/test_analysis_data_entry/Presentation/views/widgets/test_analysis_data_form_fields_widget.dart';
@@ -40,8 +43,52 @@ class TestAnalysisDataEntryView extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                AppBarWithImageAndActionButtons(
-                  haveBackArrow: true,
+                BlocBuilder<TestAnalysisDataEntryCubit,
+                    TestAnalysisDataEntryState>(
+                  buildWhen: (previous, current) =>
+                      previous.moduleGuidanceData != current.moduleGuidanceData,
+                  builder: (context, state) {
+                    return AppBarWithImageAndActionButtons(
+                      haveBackArrow: true,
+                      trailingActions: [
+                        CircleIconButton(
+                          icon: Icons.play_arrow,
+                          color:
+                              state.moduleGuidanceData?.videoLink?.isNotEmpty ==
+                                      true
+                                  ? AppColorsManager.mainDarkBlue
+                                  : Colors.grey,
+                          onTap:
+                              state.moduleGuidanceData?.videoLink?.isNotEmpty ==
+                                      true
+                                  ? () => launchYouTubeVideo(
+                                      state.moduleGuidanceData!.videoLink)
+                                  : null,
+                        ),
+                        SizedBox(width: 8.w),
+                        CircleIconButton(
+                          icon: Icons.menu_book_outlined,
+                          color: state.moduleGuidanceData?.moduleGuidanceText
+                                      ?.isNotEmpty ==
+                                  true
+                              ? AppColorsManager.mainDarkBlue
+                              : Colors.grey,
+                          onTap: state.moduleGuidanceData?.moduleGuidanceText
+                                      ?.isNotEmpty ==
+                                  true
+                              ? () {
+                                  ModuleGuidanceAlertDialog.show(
+                                    context,
+                                    title: "التحاليل الطبية",
+                                    description: state.moduleGuidanceData!
+                                        .moduleGuidanceText!,
+                                  );
+                                }
+                              : null,
+                        ),
+                      ],
+                    );
+                  },
                 ),
                 verticalSpacing(24),
                 TestAnalysisDataEntryFormFields(),

--- a/lib/features/test_laboratory/test_analysis_data_entry/logic/cubit/test_analysis_data_entry_cubit.dart
+++ b/lib/features/test_laboratory/test_analysis_data_entry/logic/cubit/test_analysis_data_entry_cubit.dart
@@ -8,6 +8,7 @@ import 'package:we_care/core/global/Helpers/app_enums.dart';
 import 'package:we_care/core/global/Helpers/extensions.dart';
 import 'package:we_care/core/global/app_strings.dart';
 import 'package:we_care/core/global/shared_repo.dart';
+import 'package:we_care/core/models/module_guidance_response_model.dart';
 import 'package:we_care/features/test_laboratory/data/models/get_analysis_by_id_response_model.dart';
 import 'package:we_care/features/test_laboratory/data/models/test_analysis_request_body_model.dart';
 import 'package:we_care/features/test_laboratory/data/models/test_table_model.dart';
@@ -45,7 +46,23 @@ class TestAnalysisDataEntryCubit extends Cubit<TestAnalysisDataEntryState> {
       emitDoctorNames(),
       emitLabCenters(),
       emitHospitalNames(),
+      emitModuleGuidanceData(),
     ]);
+  }
+
+  /// Loads the module's guidance video + text shown in the data entry app bar.
+  Future<void> emitModuleGuidanceData() async {
+    final response = await sharedRepo.getModuleGuidance(
+      WeCareMedicalModules.labTestsDataEntry.name,
+    );
+    response.when(
+      success: (response) {
+        safeEmit(state.copyWith(moduleGuidanceData: response));
+      },
+      failure: (error) {
+        safeEmit(state.copyWith(moduleGuidanceData: null));
+      },
+    );
   }
 
   void loadAnalysisDataForEditing(

--- a/lib/features/test_laboratory/test_analysis_data_entry/logic/cubit/test_analysis_data_entry_state.dart
+++ b/lib/features/test_laboratory/test_analysis_data_entry/logic/cubit/test_analysis_data_entry_state.dart
@@ -36,6 +36,8 @@ class TestAnalysisDataEntryState extends Equatable {
   final List<TableRowReponseModel> testTableRowsData;
   final List<TableRowReponseModel> enteredTableRows;
 
+  final ModuleGuidanceDataModel? moduleGuidanceData;
+
   const TestAnalysisDataEntryState({
     this.testAnalysisDataEntryStatus = RequestStatus.initial,
     this.countriesNames = const [],
@@ -65,6 +67,7 @@ class TestAnalysisDataEntryState extends Equatable {
     this.labCenters = const [],
     this.hospitalNames = const [],
     this.selectedLabCenter,
+    this.moduleGuidanceData,
   });
   const TestAnalysisDataEntryState.initial()
       : this(
@@ -96,6 +99,7 @@ class TestAnalysisDataEntryState extends Equatable {
           labCenters: const [],
           hospitalNames: const [],
           selectedLabCenter: null,
+          moduleGuidanceData: null,
         );
 
   TestAnalysisDataEntryState copyWith({
@@ -127,6 +131,7 @@ class TestAnalysisDataEntryState extends Equatable {
     List<String>? labCenters,
     List<String>? hospitalNames,
     String? selectedLabCenter,
+    ModuleGuidanceDataModel? moduleGuidanceData,
   }) {
     return TestAnalysisDataEntryState(
       selectedDate: selectedDate ?? this.selectedDate,
@@ -163,6 +168,7 @@ class TestAnalysisDataEntryState extends Equatable {
       labCenters: labCenters ?? this.labCenters,
       hospitalNames: hospitalNames ?? this.hospitalNames,
       selectedLabCenter: selectedLabCenter ?? this.selectedLabCenter,
+      moduleGuidanceData: moduleGuidanceData ?? this.moduleGuidanceData,
     );
   }
 
@@ -196,5 +202,6 @@ class TestAnalysisDataEntryState extends Equatable {
         labCenters,
         hospitalNames,
         selectedLabCenter,
+        moduleGuidanceData,
       ];
 }

--- a/lib/features/x_ray/x_ray_data_entry/Presentation/views/x_ray_data_entry_view.dart
+++ b/lib/features/x_ray/x_ray_data_entry/Presentation/views/x_ray_data_entry_view.dart
@@ -4,6 +4,9 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:we_care/core/di/dependency_injection.dart';
 import 'package:we_care/core/global/Helpers/functions.dart';
 import 'package:we_care/core/global/SharedWidgets/custom_app_bar.dart';
+import 'package:we_care/core/global/SharedWidgets/module_guidance_alert_dialog.dart';
+import 'package:we_care/core/global/SharedWidgets/shared_app_bar_widget.dart';
+import 'package:we_care/core/global/theming/color_manager.dart';
 import 'package:we_care/features/emergency_complaints/emergency_complaints_data_entry/logic/cubit/emergency_complaint_details_cubit.dart';
 import 'package:we_care/features/x_ray/data/models/user_radiology_data_reponse_model.dart';
 import 'package:we_care/features/x_ray/x_ray_data_entry/logic/cubit/x_ray_data_entry_cubit.dart';
@@ -42,8 +45,51 @@ class XrayCategoryDataEntryView extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                AppBarWithImageAndActionButtons(
-                  haveBackArrow: true,
+                BlocBuilder<XRayDataEntryCubit, XRayDataEntryState>(
+                  buildWhen: (previous, current) =>
+                      previous.moduleGuidanceData != current.moduleGuidanceData,
+                  builder: (context, state) {
+                    return AppBarWithImageAndActionButtons(
+                      haveBackArrow: true,
+                      trailingActions: [
+                        CircleIconButton(
+                          icon: Icons.play_arrow,
+                          color:
+                              state.moduleGuidanceData?.videoLink?.isNotEmpty ==
+                                      true
+                                  ? AppColorsManager.mainDarkBlue
+                                  : Colors.grey,
+                          onTap:
+                              state.moduleGuidanceData?.videoLink?.isNotEmpty ==
+                                      true
+                                  ? () => launchYouTubeVideo(
+                                      state.moduleGuidanceData!.videoLink)
+                                  : null,
+                        ),
+                        SizedBox(width: 8.w),
+                        CircleIconButton(
+                          icon: Icons.menu_book_outlined,
+                          color: state.moduleGuidanceData?.moduleGuidanceText
+                                      ?.isNotEmpty ==
+                                  true
+                              ? AppColorsManager.mainDarkBlue
+                              : Colors.grey,
+                          onTap: state.moduleGuidanceData?.moduleGuidanceText
+                                      ?.isNotEmpty ==
+                                  true
+                              ? () {
+                                  ModuleGuidanceAlertDialog.show(
+                                    context,
+                                    title: "الأشعة",
+                                    description: state.moduleGuidanceData!
+                                        .moduleGuidanceText!,
+                                  );
+                                }
+                              : null,
+                        ),
+                      ],
+                    );
+                  },
                 ),
                 verticalSpacing(24),
                 XRayDataEntryFormFields(),

--- a/lib/features/x_ray/x_ray_data_entry/logic/cubit/x_ray_data_entry_cubit.dart
+++ b/lib/features/x_ray/x_ray_data_entry/logic/cubit/x_ray_data_entry_cubit.dart
@@ -8,6 +8,7 @@ import 'package:we_care/core/global/Helpers/app_enums.dart';
 import 'package:we_care/core/global/Helpers/extensions.dart';
 import 'package:we_care/core/global/app_strings.dart';
 import 'package:we_care/core/global/shared_repo.dart';
+import 'package:we_care/core/models/module_guidance_response_model.dart';
 import 'package:we_care/core/networking/dio_serices.dart';
 import 'package:we_care/features/x_ray/data/models/body_parts_response_model.dart';
 import 'package:we_care/features/x_ray/data/models/user_radiology_data_reponse_model.dart';
@@ -198,7 +199,23 @@ class XRayDataEntryCubit extends Cubit<XRayDataEntryState> {
         emitRadiologyDoctorNames(),
         emitRadiologyCenters(),
         emitHospitalNames(),
+        emitModuleGuidanceData(),
       ],
+    );
+  }
+
+  /// Loads the module's guidance video + text shown in the data entry app bar.
+  Future<void> emitModuleGuidanceData() async {
+    final response = await sharedRepo.getModuleGuidance(
+      WeCareMedicalModules.imagingRadiologyDataEntry.name,
+    );
+    response.when(
+      success: (response) {
+        safeEmit(state.copyWith(moduleGuidanceData: response));
+      },
+      failure: (error) {
+        safeEmit(state.copyWith(moduleGuidanceData: null));
+      },
     );
   }
 

--- a/lib/features/x_ray/x_ray_data_entry/logic/cubit/x_ray_data_entry_state.dart
+++ b/lib/features/x_ray/x_ray_data_entry/logic/cubit/x_ray_data_entry_state.dart
@@ -32,6 +32,7 @@ class XRayDataEntryState extends Equatable {
   final bool isEditMode;
   final List<String> uploadedTestImages; // URLs returned from API
   final List<String> uploadedTestReports;
+  final ModuleGuidanceDataModel? moduleGuidanceData;
 
   const XRayDataEntryState({
     this.selectedPuposes = const [],
@@ -63,6 +64,7 @@ class XRayDataEntryState extends Equatable {
     this.uploadedTestReports = const [],
     this.radiologyDoctors = const [],
     this.selectedBodyPartId,
+    this.moduleGuidanceData,
   }) : super();
 
   const XRayDataEntryState.initialState()
@@ -90,6 +92,7 @@ class XRayDataEntryState extends Equatable {
           uploadedTestReports: const [],
           radiologyDoctors: const [],
           selectedBodyPartId: null,
+          moduleGuidanceData: null,
         );
 
   XRayDataEntryState copyWith({
@@ -122,6 +125,7 @@ class XRayDataEntryState extends Equatable {
     List<String>? uploadedTestReports,
     List<String>? radiologyDoctors,
     String? selectedBodyPartId,
+    ModuleGuidanceDataModel? moduleGuidanceData,
   }) {
     return XRayDataEntryState(
       xRayDataEntryStatus: xRayDataEntryStatus ?? this.xRayDataEntryStatus,
@@ -164,6 +168,7 @@ class XRayDataEntryState extends Equatable {
       uploadedTestReports: uploadedTestReports ?? this.uploadedTestReports,
       radiologyDoctors: radiologyDoctors ?? this.radiologyDoctors,
       selectedBodyPartId: selectedBodyPartId ?? this.selectedBodyPartId,
+      moduleGuidanceData: moduleGuidanceData ?? this.moduleGuidanceData,
     );
   }
 
@@ -198,5 +203,6 @@ class XRayDataEntryState extends Equatable {
         uploadedTestReports,
         radiologyDoctors,
         selectedBodyPartId,
+        moduleGuidanceData,
       ];
 }

--- a/lib/main_development.dart
+++ b/lib/main_development.dart
@@ -50,8 +50,10 @@ void main() async {
   await Hive.openBox<NewGeneticDiseaseModel>("medical_genetic_diseases");
 
   Hive.registerAdapter(MedicineAlarmModelAdapter());
-  await Hive.openBox<List<MedicineAlarmModel>>(
-      MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
+  //* opened untyped on purpose: this box stores a List value, and Hive hands a
+  //* List<dynamic> back after reading it from disk — a Box<List<MedicineAlarmModel>>
+  //* would throw on every get(). Call sites convert with List<MedicineAlarmModel>.from.
+  await Hive.openBox(MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
 
   await setUpDependencyInjection();
 

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -46,9 +46,10 @@ Future<void> main() async {
   await Hive.openBox<NewGeneticDiseaseModel>("medical_genetic_diseases");
 
   Hive.registerAdapter(MedicineAlarmModelAdapter());
-  await Hive.openBox<List<MedicineAlarmModel>>(
-    MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey,
-  );
+  //* opened untyped on purpose: this box stores a List value, and Hive hands a
+  //* List<dynamic> back after reading it from disk — a Box<List<MedicineAlarmModel>>
+  //* would throw on every get(). Call sites convert with List<MedicineAlarmModel>.from.
+  await Hive.openBox(MedicinesApiConstants.alarmsScheduledPerMedicineBoxKey);
 
   await setUpDependencyInjection();
 


### PR DESCRIPTION
## Summary

Ending a medicine now collects an explicit end date from the user instead of silently stamping today, and the medicine is only treated as ended — with its alarms cancelled — after the API confirms it. The branch also carries a Hive crash fix on the medicine alarms box plus a set of smaller module fixes.

## Changes

**Medicine end date**
- `endDate` added to `MedicineModel` and `MedicineDataEntryRequestBody`, and an optional "تاريخ إنتهاء الدواء" picker added to the data entry form (lower-bounded at the start date).
- New `showEndMedicineConfirmationDialog` — confirms the action and collects the end date, rejecting dates before the medicine's start date.
- `MedicineViewCubit.endMedicine` replaces `updateMedicineActiveStatus`: no optimistic flip, re-entrancy guarded, and alarms are cancelled only on a confirmed end. Alarm cancellation failures are logged rather than surfaced as a failed request.
- `updateMedicineStatus` now sends `endDate` (was `startDate`) and both status endpoints return `(isActiveMedicine, endDate)` via a shared parser tolerant of both root and `data`-envelope response shapes.
- New `isStatusResolved` state flag so "status not loaded / request failed" is no longer indistinguishable from "medicine ended" — a failed fetch renders `—`, never an ended medicine.
- Ended medicines render read-only ("منتهي") with an end-date tile; there is no re-activation path.

**Root cause (Hive crash)**
The medicine alarms box was opened as `Box<List<MedicineAlarmModel>>`, but Hive returns `List<dynamic>` when reading a list value back from disk, so every `get()` threw a cast error. The box is now opened untyped in both entrypoints, with call sites converting via `List<MedicineAlarmModel>.from`.

**Other fixes**
- Module guidance video/text wired into the x-ray, lab test and surgery data entry app bars.
- Surgeries filtered by region (`surgeryRegion`) instead of surgery name.
- Category ticket counters extended to the remaining 12 modules.
- Vaccines, risky behaviour and the monthly health survey added to the medical compatibility profile model.
- Removed surgery filter endpoints/repo methods copy-pasted into the allergy feature.
- Pull-to-refresh on the medicines list fixed — it read the cubit from a context above its own provider.
- Prescription card label `المرض` → `التشخيص`.
- Dead `calculateMedicineStatus` helper removed (superseded by the server-provided status).

## Testing

`flutter analyze` — no errors (327 pre-existing warnings/infos, unchanged). Not exercised against a live backend; the `UpdateMedicineStatus` request/response contract (`endDate` + `isActiveMedicine`) should be confirmed with the API team before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)